### PR TITLE
Complete zserio round-trip test: serialize, deserialize, serialize

### DIFF
--- a/src/ztype/bits_decode.rs
+++ b/src/ztype/bits_decode.rs
@@ -16,10 +16,12 @@ pub fn read_signed_bits(reader: &mut BitReader, bits: u8) -> i64 {
     reader.read_i64(bits).expect("failed to read bits")
 }
 
-pub fn read_u32(reader: &mut BitReader) -> u32 { read_unsigned_bits(reader, 32) as u32 }
-pub fn read_u16(reader: &mut BitReader) -> u16 { read_unsigned_bits(reader, 16) as u16 }
-pub fn read_u8(reader: &mut BitReader) -> u8 { read_unsigned_bits(reader, 8) as u8 }
+pub fn read_u64(reader: &mut BitReader) -> u64 { reader.read_u64(64).unwrap() }
+pub fn read_u32(reader: &mut BitReader) -> u32 { reader.read_u32(32).unwrap() }
+pub fn read_u16(reader: &mut BitReader) -> u16 { reader.read_u16(16).unwrap() }
+pub fn read_u8(reader: &mut BitReader) -> u8 { reader.read_u8(8).unwrap() }
 
-pub fn read_i32(reader: &mut BitReader) -> i32 { read_signed_bits(reader, 32) as i32 }
-pub fn read_i16(reader: &mut BitReader) -> i16 { read_signed_bits(reader, 16) as i16 }
-pub fn read_i8(reader: &mut BitReader) -> i8 { read_signed_bits(reader, 8) as i8 }
+pub fn read_i64(reader: &mut BitReader) -> i64 { reader.read_i64(64).unwrap() }
+pub fn read_i32(reader: &mut BitReader) -> i32 { reader.read_i32(32).unwrap() }
+pub fn read_i16(reader: &mut BitReader) -> i16 { reader.read_i16(16).unwrap() }
+pub fn read_i8(reader: &mut BitReader) -> i8 { reader.read_i8(8).unwrap() }

--- a/src/ztype/bits_encode.rs
+++ b/src/ztype/bits_encode.rs
@@ -19,7 +19,7 @@ pub fn write_u32(writer: &mut BitWriter, v: u32) { write_unsigned_bits(writer, v
 pub fn write_u16(writer: &mut BitWriter, v: u32) { write_unsigned_bits(writer, v as u64, 16); }
 pub fn write_u8(writer: &mut BitWriter, v: u32) { write_unsigned_bits(writer, v as u64, 8); }
 
-pub fn write_i64(writer: &mut BitWriter, v: i64) { write_signed_bits(writer, v, 64); }
-pub fn write_i32(writer: &mut BitWriter, v: i32) { write_signed_bits(writer, v as i64, 32); }
-pub fn write_i16(writer: &mut BitWriter, v: i16) { write_signed_bits(writer, v as i64, 16); }
-pub fn write_i8(writer: &mut BitWriter, v: i8) { write_signed_bits(writer, v as i64, 8); }
+pub fn write_i64(writer: &mut BitWriter, v: i64) { writer.write_i64(v, 64).expect("failed to write i64"); }
+pub fn write_i32(writer: &mut BitWriter, v: i32) { writer.write_i32(v, 32).expect("failed to write i32"); }
+pub fn write_i16(writer: &mut BitWriter, v: i16) { writer.write_i16(v, 16).expect("failed to write i16"); }
+pub fn write_i8(writer: &mut BitWriter, v: i8) { writer.write_i8(v, 8).expect("failed to write i8"); }

--- a/src/ztype/mod.rs
+++ b/src/ztype/mod.rs
@@ -15,10 +15,12 @@ pub use self::bits_encode::write_u32;
 pub use self::bits_encode::write_u16;
 pub use self::bits_encode::write_u8;
 
+pub use self::bits_decode::read_i64;
 pub use self::bits_decode::read_i32;
 pub use self::bits_decode::read_i16;
 pub use self::bits_decode::read_i8;
 
+pub use self::bits_decode::read_u64;
 pub use self::bits_decode::read_u32;
 pub use self::bits_decode::read_u16;
 pub use self::bits_decode::read_u8;

--- a/src/ztype/string_decode.rs
+++ b/src/ztype/string_decode.rs
@@ -1,7 +1,13 @@
 use bitreader::BitReader;
 
+use crate::ztype::varuint_decode::read_varsize;
 
 pub fn read_string(reader: &mut BitReader) -> String {
-    // stub
-    String::from("")
+    // zserio first writes the string length as a varsize uint
+    let str_len = read_varsize(reader) as usize;
+
+    // create a buffer to store the string
+    let mut buffer = vec![0_u8; str_len];
+    reader.read_u8_slice(&mut buffer).expect("failed to read string from buffer");
+    String::from_utf8(buffer).unwrap()
 }

--- a/src/ztype/varuint_decode.rs
+++ b/src/ztype/varuint_decode.rs
@@ -2,34 +2,26 @@
 use bitreader::BitReader;
 use rstest::rstest;
 
-pub fn read_varuint32(mut reader: BitReader) -> u32 {
-    let mut b = reader.read_u32(8).unwrap();
-    let mut has_next_byte = (b & 0x80) != 0;
-    let mut value = b & (0x7f);
 
-    for _ in 0..2 {
-        if !has_next_byte {
-            break
-        }
-        
-        b = reader.read_u32(8).unwrap();
-        has_next_byte = (b & 0x80) != 0;
-        value = (value << 7) | (b & (0x7f));
-    }
-    if has_next_byte {
-        b = reader.read_u32(8).unwrap();
-        value = (value << 8) | b;
-    }
-    value
+pub fn read_varsize(reader: &mut BitReader) -> u64 {
+    read_sized_uint(reader, 5)
+}
+
+pub fn read_varuint32( reader: &mut BitReader) -> u32 {
+    read_sized_uint(reader, 4) as u32
 }
 
 
-pub fn read_varuint(mut reader: BitReader) -> u64 {
+pub fn read_varuint(reader: &mut BitReader) -> u64 {
+    read_sized_uint(reader, 9)
+}
+
+fn read_sized_uint(reader: &mut BitReader, num_byes: u8) -> u64 {
     let mut b = reader.read_u64(8).unwrap();
     let mut has_next_byte = (b & 0x80) != 0;
     let mut value = b & (0x7f);
 
-    for _ in 0..7 {
+    for _ in 0..num_byes-2 {
         if !has_next_byte {
             break
         }
@@ -53,7 +45,7 @@ mod tests {
     #[case(0xFFFFFFFF, 536870911)] // maximum possible value
     fn test_read_varuint32(#[case] input: u32, #[case] expected: u32) {
         let slice_of_u8 =  &input.to_be_bytes();
-        let reader = BitReader::new(slice_of_u8);
-        assert_eq!(read_varuint32(reader), expected);
+        let mut reader = BitReader::new(slice_of_u8);
+        assert_eq!(read_varuint32(&mut reader), expected);
     } 
 }

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -2,13 +2,15 @@ pub mod reference_modules {
     pub mod core {
        pub mod types;
     }
-   }
+}
    
-   use crate::reference_modules::core::types::{
-       ValueWrapper,
-       Color,   
-   };
-   
+use crate::reference_modules::core::types::{
+    ValueWrapper,
+    Color,   
+};
+
+use rust_bitwriter::BitWriter;
+use bitreader::BitReader;
 
 fn main() {
     // This test generates a test structure, serializes it, deserializes it, and ensures
@@ -16,16 +18,38 @@ fn main() {
 
     // Instantiate the data
     let value_wrapper = ValueWrapper::ValueWrapper{
-        value:1,
-        other_value:3,
-        enum_value:Color::Color::BLACK,
-        description:String::from("te2222st"),
-        opt_int_32:Option::from(12),
+        value: 1,
+        other_value: 3,
+        enum_value: Color::Color::BLACK,
+        description: String::from("te2222st"),
+        opt_int_32: Option::from(12),
     };
     
-    // TODO serialize
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    value_wrapper.marshal_zserio(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_byes = bitwriter.data();
 
-    // TODO deserialize
+    // deserialize
+    let mut other_value_wrapper = ValueWrapper::ValueWrapper{
+        value: 0,
+        other_value: 0,
+        enum_value: Color::Color::BLACK,
+        description: String::from(""),
+        opt_int_32: Option::None,
+    };
+    let mut bitreader = BitReader::new(&serialized_byes);
+    other_value_wrapper.unmarshal_zserio(&mut bitreader);
 
-    // TODO compare
+    assert!(other_value_wrapper.value == value_wrapper.value);
+    assert!(other_value_wrapper.other_value == value_wrapper.other_value);
+    assert!(other_value_wrapper.description == value_wrapper.description);
+    
+    // serialize the new structure again, and ensure it is binary identical
+    let mut other_bitwriter = BitWriter::new();
+    other_value_wrapper.marshal_zserio(&mut other_bitwriter);
+    other_bitwriter.close().expect("failed to close bit stream");
+    let other_serialized_bytes = other_bitwriter.data();
+    assert!(other_serialized_bytes == serialized_byes);
 }


### PR DESCRIPTION
- This commit completes the round-trip test, by enhancing it to create a test szerio structure, serializing it, deserializing it again, and ensuring the content is identical.
- Additionally, the deserialized object is serialized again, with the generated bytes expected to be identical to the bytes from the first object.
- Implemented the deserialization of strings, to make the test pass.