### PR TITLE
Support Choice Expression Evaluation

### DIFF
--- a/src/internal/ast/zchoice.rs
+++ b/src/internal/ast/zchoice.rs
@@ -1,9 +1,16 @@
-use crate::internal::ast::expression::Expression;
+use crate::internal::ast::expression::{
+    EvaluationState, Expression, ExpressionFlag, ExpressionType,
+};
 use crate::internal::ast::field::Field;
 use crate::internal::ast::parameter::Parameter;
 use crate::internal::ast::zfunction::ZFunction;
+use crate::internal::parser::gen::zserioparser::{DOT, ID};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use std::collections::HashMap;
+
+use crate::internal::compiler::symbol_scope::{ModelScope, PackageScope, Symbol};
 pub struct ZChoiceCase {
     pub conditions: Vec<Rc<RefCell<Expression>>>,
     pub field: Option<Box<Field>>,
@@ -12,9 +19,121 @@ pub struct ZChoiceCase {
 pub struct ZChoice {
     pub name: String,
     pub template_parameters: Vec<String>,
-    pub type_parameters: Vec<Parameter>,
-    pub selector_expression: Option<Rc<RefCell<Expression>>>,
+    pub type_parameters: Vec<Rc<RefCell<Parameter>>>,
+    pub selector_expression: Rc<RefCell<Expression>>,
     pub cases: Vec<ZChoiceCase>,
     pub default_case: Option<ZChoiceCase>,
     pub functions: Vec<ZFunction>,
+}
+
+impl ZChoice {
+    pub fn evaluate(&mut self, scope: &mut ModelScope) {
+        // Ignore packages that are templated. They cannot be evaluated. Only their templated
+        // instances will be evaluated.
+        if !self.template_parameters.is_empty() {
+            return;
+        }
+        self.selector_expression
+            .as_ref()
+            .borrow_mut()
+            .evaluate(scope);
+
+        // Add the enumeration type prefix, if the selector is an enumeration type.
+        self.add_enumeration_type_prefix_to_choice_cases();
+
+        for param in &self.type_parameters {
+            param.as_ref().borrow().zserio_type.evaluate(scope);
+        }
+        for case in &self.cases {
+            if let Some(case_field) = &case.field {
+                case_field.evaluate(scope);
+            }
+            for case_condition in &case.conditions {
+                case_condition.as_ref().borrow_mut().evaluate(scope);
+            }
+        }
+        if let Some(default_field) = &self.default_case {
+            if let Some(case_field) = &default_field.field {
+                case_field.evaluate(scope);
+            }
+            for case_condition in &default_field.conditions {
+                case_condition.as_ref().borrow_mut().evaluate(scope);
+            }
+        }
+    }
+
+    fn add_enumeration_type_prefix_to_choice_cases(&mut self) {
+        // For enumerator parameters, this function will look for choice cases that are not fully
+        // described, and replaces them by a dot expression.
+        // This is needed to satisfy the zserio rule:
+        // -- When the selector expression has an enumeration type, the enumeration type prefix
+        // -- may be omitted from the case label literals.
+        // An example would look like this:
+        // case ENUM_VALUE:
+        // will be replaced by:
+        // case EnumType.ENUM_VALUE
+        for case in &mut self.cases {
+            for condition in &mut case.conditions.iter_mut() {
+                let mut dot_expression = None;
+                {
+                    let condition_expression = condition.as_ref().borrow();
+                    if condition_expression.expression_type == ID {
+                        match &self.selector_expression.as_ref().borrow().result_type {
+                            ExpressionType::Parameter(p) => {
+                                let mut operand2 = Box::from(condition_expression.clone());
+                                operand2.flag = ExpressionFlag::IsDotExpressionRightOperand;
+
+                                dot_expression = Option::from(Expression {
+                                    expression_type: DOT,
+                                    flag: ExpressionFlag::None,
+                                    operand1: Option::from(Box::new(Expression {
+                                        expression_type: ID,
+                                        text: p.as_ref().borrow().zserio_type.name.clone(),
+                                        flag: ExpressionFlag::None,
+                                        operand1: None,
+                                        operand2: None,
+                                        operand3: None,
+                                        result_type: ExpressionType::Other,
+                                        fully_resolved: false,
+                                        evaluation_state: EvaluationState::NotEvaluated,
+                                    })),
+                                    operand2: Option::from(operand2),
+                                    operand3: None,
+                                    text: "".into(),
+                                    result_type: ExpressionType::Other,
+                                    fully_resolved: false,
+                                    evaluation_state: EvaluationState::NotEvaluated,
+                                });
+                            }
+                            _ => panic!("selector expression is not a parameter"),
+                        }
+                    }
+                }
+                if let Some(new_dot_expression) = dot_expression {
+                    *condition = Rc::from(RefCell::from(new_dot_expression));
+                }
+            }
+        }
+    }
+}
+
+pub fn add_choice_to_scope(z_choice: &Rc<RefCell<ZChoice>>, package_scope: &mut PackageScope) {
+    // Create a local scope, which contains all symbols within this structure
+    let mut local_symbols = HashMap::new();
+    for rc_param in z_choice.borrow().type_parameters.iter() {
+        let param = rc_param.as_ref().borrow();
+        local_symbols.insert(param.name.clone(), Symbol::Parameter(rc_param.clone()));
+    }
+    //for (i, field) in z_choice.borrow().cases.iter().enumerate() {
+    //local_symbols.insert(field.name.clone(), Symbol::Field(z_choice.clone(), i));
+    //}
+    package_scope
+        .local_symbols
+        .insert(z_choice.borrow().name.clone(), local_symbols);
+
+    // Add the struct name itself to the package scope.
+    package_scope.file_symbols.insert(
+        z_choice.borrow().name.clone(),
+        Symbol::Choice(z_choice.clone()),
+    );
 }

--- a/src/internal/ast/zstruct.rs
+++ b/src/internal/ast/zstruct.rs
@@ -10,7 +10,7 @@ pub struct ZStruct {
     pub name: String,
     pub comment: String,
     pub template_parameters: Vec<String>,
-    pub type_parameters: Vec<Parameter>,
+    pub type_parameters: Vec<Rc<RefCell<Parameter>>>,
     pub fields: Vec<Field>,
     pub functions: Vec<ZFunction>,
 }
@@ -24,7 +24,7 @@ impl ZStruct {
         }
 
         for param in &self.type_parameters {
-            param.zserio_type.evaluate(scope);
+            param.as_ref().borrow().zserio_type.evaluate(scope);
         }
         for field in &self.fields {
             field.evaluate(scope);
@@ -35,8 +35,9 @@ impl ZStruct {
 pub fn add_struct_to_scope(z_struct: &Rc<RefCell<ZStruct>>, package_scope: &mut PackageScope) {
     // Create a local scope, which contains all symbols within this structure
     let mut local_symbols = HashMap::new();
-    for (i, param) in z_struct.borrow().type_parameters.iter().enumerate() {
-        local_symbols.insert(param.name.clone(), Symbol::Parameter(z_struct.clone(), i));
+    for rc_param in z_struct.borrow().type_parameters.iter() {
+        let param = rc_param.as_ref().borrow();
+        local_symbols.insert(param.name.clone(), Symbol::Parameter(rc_param.clone()));
     }
     for (i, field) in z_struct.borrow().fields.iter().enumerate() {
         local_symbols.insert(field.name.clone(), Symbol::Field(z_struct.clone(), i));

--- a/src/internal/ast/zunion.rs
+++ b/src/internal/ast/zunion.rs
@@ -1,10 +1,11 @@
 use crate::internal::ast::{field::Field, parameter::Parameter, zfunction::ZFunction};
-
+use std::cell::RefCell;
+use std::rc::Rc;
 pub struct ZUnion {
     pub name: String,
     pub comment: String,
     pub template_parameters: Vec<String>,
-    pub type_parameters: Vec<Parameter>,
+    pub type_parameters: Vec<Rc<RefCell<Parameter>>>,
     pub fields: Vec<Field>,
     pub functions: Vec<ZFunction>,
 }

--- a/src/internal/compiler/symbol_scope.rs
+++ b/src/internal/compiler/symbol_scope.rs
@@ -1,6 +1,9 @@
 use crate::internal::{
     ast::{
         package::{ZImport, ZPackage},
+        parameter::Parameter,
+        zchoice::add_choice_to_scope,
+        zchoice::ZChoice,
         zconst::ZConst,
         zenum::{add_enum_to_scope, ZEnum},
         zstruct::add_struct_to_scope,
@@ -18,12 +21,13 @@ use std::rc::Rc;
 #[derive(Clone)]
 pub enum Symbol {
     Struct(Rc<RefCell<ZStruct>>),
+    Choice(Rc<RefCell<ZChoice>>),
     Enum(Rc<RefCell<ZEnum>>),
     EnumItem(Rc<RefCell<ZEnum>>, usize),
     Subtype(Rc<RefCell<Subtype>>),
     Const(Rc<RefCell<ZConst>>),
     Field(Rc<RefCell<ZStruct>>, usize),
-    Parameter(Rc<RefCell<ZStruct>>, usize),
+    Parameter(Rc<RefCell<Parameter>>),
 }
 /// A struct to hold a reference to a specific symbol. It provides the package, symbol and symbol name.
 pub struct SymbolReference {
@@ -135,6 +139,9 @@ impl PackageScope {
         for zstruct in &package.structs {
             add_struct_to_scope(zstruct, &mut scope);
         }
+        for zchoice in &package.zchoices {
+            add_choice_to_scope(zchoice, &mut scope);
+        }
         for zenum in &package.enums {
             add_enum_to_scope(zenum, &mut scope);
         }
@@ -161,7 +168,7 @@ impl PackageScope {
                     }
                     _ => (),
                 },
-                _ => panic!("a nonexisting symbol was referenced within the package"),
+                _ => (),
             }
         }
 

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -32,12 +32,15 @@ pub fn generate_struct(
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zstruct.type_parameters {
-        let param_type = ztype_to_rust_type(param.zserio_type.as_ref());
+        let param_type = ztype_to_rust_type(param.as_ref().borrow().zserio_type.as_ref());
         // Possible improvement: currently the parameters are copied instead of taken the reference.
         // It would be great to change that to references to avoid unnecessary copying, but this is
         // painful in rust due to the lifetime checks.
         // Because I am lazy, this implementation will just copy values over.
-        let gen_param_field = gen_struct.new_field(convert_field_name(&param.name), param_type);
+        let gen_param_field = gen_struct.new_field(
+            convert_field_name(&param.as_ref().borrow().name),
+            param_type,
+        );
         gen_param_field.vis("pub");
     }
 
@@ -65,7 +68,7 @@ pub fn generate_struct(
     new_fn.line(format!("{} {{", &rust_type_name));
 
     for param in &zstruct.type_parameters {
-        new_param(new_fn, param);
+        new_param(new_fn, &param.as_ref().borrow());
     }
 
     for field in &zstruct.fields {

--- a/src/internal/model.rs
+++ b/src/internal/model.rs
@@ -58,13 +58,23 @@ impl Model {
                 scope.scope_stack.pop();
             }
 
-            for z_enum in &mut pkg.enums {
+            for z_enum in &pkg.enums {
                 scope.scope_stack.push(ScopeLocation {
                     package: pkg.name.clone(),
                     import_symbol: None,
                     symbol_name: Option::from(z_enum.as_ref().borrow().name.clone()),
                 });
                 z_enum.borrow_mut().evaluate(scope);
+                scope.scope_stack.pop();
+            }
+
+            for z_choice in &pkg.zchoices {
+                scope.scope_stack.push(ScopeLocation {
+                    package: pkg.name.clone(),
+                    import_symbol: None,
+                    symbol_name: Option::from(z_choice.as_ref().borrow().name.clone()),
+                });
+                z_choice.borrow_mut().evaluate(scope);
                 scope.scope_stack.pop();
             }
 


### PR DESCRIPTION
- This PR will add support to go-zserio to support evaluating the Choice type (http://zserio.org/doc/ZserioLanguageOverview.html#compound-types).
- Expressions for Choice types are very similar to structs. Unlike structs, Choices also have a selector expression, which based on an enum value select a subset of fields. In a way, they are very similar to rust enumerations (that support specific types for each enum value).
- This PR only implements the expression evaluation logic. The code for Choice rust implementation is not yet implemented.