### PR TITLE
Implement Code Generation for Expression

### DIFF
--- a/src/internal/ast/expression.rs
+++ b/src/internal/ast/expression.rs
@@ -113,6 +113,7 @@ impl Expression {
             0xFFFFF => (), // Ignore
             _ => panic!("unsupported expression type"),
         }
+        self.evaluation_state = EvaluationState::Completed;
     }
 
     fn evaluate_paranthesized_expression(&mut self) {

--- a/src/internal/generator.rs
+++ b/src/internal/generator.rs
@@ -2,6 +2,7 @@ mod array;
 pub mod bitsize;
 pub mod decode;
 pub mod encode;
+pub mod expression;
 pub mod file_generator;
 pub mod model;
 pub mod native_type;

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -1,0 +1,66 @@
+use crate::internal::ast::expression::{EvaluationState, Expression, ExpressionType};
+use crate::internal::generator::types::{convert_to_enum_field_name, custom_type_to_rust_type};
+use crate::internal::parser::gen::zserioparser::{
+    AND, BANG, DIVIDE, DOT, ID, INDEX, LBRACKET, LPAREN, LSHIFT, MINUS, MODULO, MULTIPLY, OR, PLUS,
+    RPAREN, RSHIFT, TILDE, XOR,
+};
+
+pub struct ExpressionGenerationResult {
+    pub generated_value: String,
+    pub is_lvalue: bool,
+    pub lvalue_name: String,
+}
+
+pub fn generate_expression(expression: &Expression) -> String {
+    assert!(expression.evaluation_state == EvaluationState::Completed);
+    return match expression.expression_type {
+        LPAREN => format!(
+            "({})",
+            generate_expression(&expression.operand1.as_ref().unwrap())
+        ),
+        RPAREN => format!(
+            "{}()",
+            generate_expression(&expression.operand1.as_ref().unwrap())
+        ),
+        DOT => generate_dot_expression(expression),
+        /*
+        PLUS => self.evaluate_arithmetic_expression(),
+        MINUS => self.evaluate_arithmetic_expression(),
+        MULTIPLY => self.evaluate_arithmetic_expression(),
+        DIVIDE => self.evaluate_arithmetic_expression(),
+        MODULO => self.evaluate_arithmetic_expression(),
+        BANG => self.evaluate_logical_negation(),
+        TILDE => self.evaluate_bitwise_negation(),
+        AND => self.evaluate_bitwise_expression(),
+        OR => self.evaluate_bitwise_expression(),
+        XOR => self.evaluate_bitwise_expression(),
+        LSHIFT => self.evaluate_bitwise_expression(),
+        RSHIFT => self.evaluate_bitwise_expression(),
+        INDEX => self.evaluate_index_expression(),
+        */
+        ID => generate_identifier_expression(expression),
+        /*
+        0xFFFFF => (), // Ignore
+         */
+        _ => panic!("unsupported expression type"),
+    };
+}
+
+fn generate_dot_expression(expression: &Expression) -> String {
+    let op1 = expression.operand1.as_ref().unwrap();
+
+    return match &op1.result_type {
+        ExpressionType::Enum(z_enum) => {
+            format!(
+                "{}::{}",
+                custom_type_to_rust_type(&z_enum.as_ref().borrow().name),
+                convert_to_enum_field_name(&expression.operand2.as_ref().unwrap().text)
+            )
+        }
+        _ => panic!("unsupported dot expression"),
+    };
+}
+
+fn generate_identifier_expression(expression: &Expression) -> String {
+    expression.text.clone()
+}

--- a/src/internal/generator/types.rs
+++ b/src/internal/generator/types.rs
@@ -2,6 +2,8 @@ use crate::internal::ast::type_reference::TypeReference;
 use convert_case::{Case, Casing};
 use std::result::Result;
 
+const RESERVED_RUST_KEYWORDS: &'static [&'static str] = &["type", "struct"];
+
 pub fn to_rust_module_name(name: &String) -> String {
     name.to_case(Case::Snake)
 }
@@ -11,6 +13,9 @@ pub fn to_rust_type_name(name: &String) -> String {
 }
 
 pub fn convert_field_name(name: &String) -> String {
+    if RESERVED_RUST_KEYWORDS.contains(&name.as_str()) {
+        return format!("z_{}", name.to_case(Case::Snake));
+    }
     name.to_case(Case::Snake)
 }
 
@@ -24,7 +29,15 @@ pub fn ztype_to_rust_type(ztype: &TypeReference) -> String {
         return zserio_to_rust_type(&ztype.name).expect("type mapping failed");
     }
     // the type is a custom type, defined in some zserio file.
-    to_rust_module_name(&ztype.name) + "::" + to_rust_type_name(&ztype.name).as_str()
+    custom_type_to_rust_type(&ztype.name)
+}
+
+pub fn custom_type_to_rust_type(name: &String) -> String {
+    format!(
+        "{}::{}",
+        to_rust_module_name(&name),
+        to_rust_type_name(&name)
+    )
 }
 
 pub fn zserio_to_rust_type(name: &str) -> Result<String, &'static str> {


### PR DESCRIPTION
- This commit will add support to generate rust code for zserio expression.
- It so far only supports a few basic expressions, such as enum dot expressions, and regular identifiers.