### PR TITLE
Add Support for Template Instantiations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ convert_case = "0.6.0"
 duplicate = "1.0.0"
 half = "2.3.1"
 num = "0.4.0"
+proc-macro2 = "1.0.66"
 rstest = "0.16.0"
 rust-bitwriter = { git = "https://github.com/Danaozhong/rust-bitwriter", version = "0.0.1" }
 rust-format = "0.3.4"

--- a/src/internal/ast/field.rs
+++ b/src/internal/ast/field.rs
@@ -3,12 +3,15 @@ use crate::internal::compiler::symbol_scope::ModelScope;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::string::String;
+
+#[derive(Clone)]
 pub struct Array {
     pub is_packed: bool,
     pub is_implicit: bool,
     pub array_length_expression: Option<Rc<RefCell<Expression>>>,
 }
 
+#[derive(Clone)]
 pub struct Field {
     pub name: String,
     pub zserio_name: String,

--- a/src/internal/ast/package.rs
+++ b/src/internal/ast/package.rs
@@ -1,5 +1,6 @@
 use crate::internal::ast::{zenum::ZEnum, zstruct::ZStruct};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::string::String;
 
@@ -20,8 +21,8 @@ pub struct ZPackage {
     pub comment: String,
 
     pub imports: Vec<ZImport>,
-    pub structs: Vec<Rc<RefCell<ZStruct>>>,
-    pub zchoices: Vec<Rc<RefCell<ZChoice>>>,
+    pub structs: HashMap<String, Rc<RefCell<ZStruct>>>,
+    pub zchoices: HashMap<String, Rc<RefCell<ZChoice>>>,
     pub zunions: Vec<Rc<RefCell<ZUnion>>>,
     pub enums: Vec<Rc<RefCell<ZEnum>>>,
     pub consts: Vec<Rc<RefCell<ZConst>>>,

--- a/src/internal/ast/parameter.rs
+++ b/src/internal/ast/parameter.rs
@@ -1,5 +1,6 @@
 use crate::internal::ast::type_reference::TypeReference;
 
+#[derive(Clone)]
 pub struct Parameter {
     pub name: String,
     pub zserio_type: Box<TypeReference>,

--- a/src/internal/ast/zchoice.rs
+++ b/src/internal/ast/zchoice.rs
@@ -11,11 +11,14 @@ use std::rc::Rc;
 use std::collections::HashMap;
 
 use crate::internal::compiler::symbol_scope::{ModelScope, PackageScope, Symbol};
+
+#[derive(Clone)]
 pub struct ZChoiceCase {
     pub conditions: Vec<Rc<RefCell<Expression>>>,
     pub field: Option<Box<Field>>,
 }
 
+#[derive(Clone)]
 pub struct ZChoice {
     pub name: String,
     pub template_parameters: Vec<String>,

--- a/src/internal/compiler/mod.rs
+++ b/src/internal/compiler/mod.rs
@@ -1,1 +1,2 @@
 pub mod symbol_scope;
+pub mod template_instantiation;

--- a/src/internal/compiler/symbol_scope.rs
+++ b/src/internal/compiler/symbol_scope.rs
@@ -72,12 +72,19 @@ impl ModelScope {
             package_scopes: HashMap::new(),
             scope_stack: vec![],
         };
-        for package in &model.packages {
+        for package in model.packages.values() {
             scope
                 .package_scopes
                 .insert(package.name.clone(), PackageScope::build_scope(package));
         }
         scope
+    }
+
+    pub fn get_package_scope(&mut self) -> &mut PackageScope {
+        let evaluation_scope = self.scope_stack.last().unwrap();
+        self.package_scopes
+            .get_mut(&evaluation_scope.package)
+            .unwrap()
     }
 
     pub fn resolve_symbol(&self, name: &String) -> SymbolReference {
@@ -137,10 +144,10 @@ impl PackageScope {
             imports: package.imports.to_vec(),
         };
 
-        for zstruct in &package.structs {
+        for zstruct in package.structs.values() {
             add_struct_to_scope(zstruct, &mut scope);
         }
-        for zchoice in &package.zchoices {
+        for zchoice in package.zchoices.values() {
             add_choice_to_scope(zchoice, &mut scope);
         }
         for zenum in &package.enums {

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -1,0 +1,307 @@
+use crate::internal::ast::field::Field;
+use crate::internal::ast::package::ZPackage;
+use crate::internal::ast::parameter::Parameter;
+use crate::internal::ast::type_reference::TypeReference;
+use crate::internal::ast::zchoice::{add_choice_to_scope, ZChoice, ZChoiceCase};
+use crate::internal::ast::zstruct::{add_struct_to_scope, ZStruct};
+use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+pub fn instantiate_type(
+    pkg: &mut ZPackage,
+    scope: &mut ModelScope,
+    zserio_type: &TypeReference,
+    name: &str,
+) -> TypeReference {
+    // A template instantiation is only possible if the type accepts template arguments.
+    // For types that are no templates, return the type itself.
+    if zserio_type.template_arguments.len() == 0 {
+        return zserio_type.clone();
+    }
+
+    let mut new_type_name = String::from(name);
+    if new_type_name == "" {
+        // in case no name is provided, a new name needs to be generated.
+        new_type_name = generate_instantiated_name(zserio_type);
+    }
+
+    let symbol = scope.resolve_symbol(&zserio_type.name);
+    match symbol.symbol {
+        Symbol::Struct(s) => {
+            return instantiate_struct(
+                pkg,
+                scope,
+                &s.as_ref().borrow(),
+                &zserio_type.template_arguments,
+                &new_type_name,
+            );
+        }
+        Symbol::Choice(c) => {
+            return instantiate_choice(
+                pkg,
+                scope,
+                &c.as_ref().borrow(),
+                &zserio_type.template_arguments,
+                &new_type_name,
+            );
+        }
+        _ => panic!("unsupported type for template instantiation"),
+    }
+}
+
+fn generate_instantiated_name(type_reference: &TypeReference) -> String {
+    let mut new_name = type_reference.name.clone();
+    for template_arg in &type_reference.template_arguments {
+        new_name += template_arg.name.as_str();
+    }
+    new_name
+}
+
+fn instantiate_struct(
+    pkg: &mut ZPackage,
+    scope: &mut ModelScope,
+    z_struct: &ZStruct,
+    template_arguments: &Vec<Box<TypeReference>>,
+    instantiated_name: &String,
+) -> TypeReference {
+    assert!(z_struct.template_parameters.len() > 0);
+    assert!(z_struct.template_parameters.len() == template_arguments.len());
+
+    let new_type_ref = TypeReference {
+        is_builtin: false,
+        package: pkg.name.clone(),
+        name: instantiated_name.clone(),
+        bits: 0,
+        template_arguments: vec![],
+        type_arguments: vec![],
+        length_expression: None,
+    };
+
+    if pkg.structs.contains_key(instantiated_name) {
+        // The structure was already instantiated, there is no need to instantiate it again.
+        // Return a new reference to the already existing type.
+        return new_type_ref;
+    }
+
+    // The instantiated struct doesn't exist yet. Start by instantiating the
+    // template parameter itself.
+    let mut instantiated_types: HashMap<String, TypeReference> = HashMap::new();
+    for (index, template_arg) in template_arguments.iter().enumerate() {
+        // In case the type instantiation is a template itself, it must be instantiated
+        // before mapping it. In case the template argument itself is not a template,
+        // instantiate_type() will just pass the type through.
+        let instantiated_type = instantiate_type(pkg, scope, template_arg, "");
+        instantiated_types.insert(
+            z_struct.template_parameters[index].clone(),
+            instantiated_type,
+        );
+    }
+
+    let mut instantiated_struct = ZStruct {
+        name: instantiated_name.clone(),
+        comment: z_struct.comment.clone(),
+        template_parameters: vec![],
+        type_parameters: vec![],
+        fields: vec![],
+        functions: vec![],
+    };
+
+    // Instantiate the fields
+    for field in &z_struct.fields {
+        instantiated_struct
+            .fields
+            .push(instantiate_field(pkg, scope, field, &instantiated_types));
+    }
+    // Instantiate the parameters
+    for rc_param in &z_struct.type_parameters {
+        // Check if the parameter is a templated type
+        let param = rc_param.as_ref().borrow();
+        if instantiated_types.contains_key(&param.zserio_type.name) {
+            // The parameter is a templated type, so replace the parameter
+            // type by a reference to the newly instantiated type.
+            instantiated_struct
+                .type_parameters
+                .push(Rc::new(RefCell::new(Parameter {
+                    name: param.name.clone(),
+                    zserio_type: Box::new(instantiated_types[&param.zserio_type.name].clone()),
+                })));
+        } else {
+            // The parameter is not templated, and is not affected by template instantiation.
+            instantiated_struct
+                .type_parameters
+                .push(Rc::new(RefCell::new(param.clone())));
+        }
+    }
+
+    // Add the newly added structure to the package.
+    pkg.structs.insert(
+        instantiated_name.clone(),
+        Rc::from(RefCell::from(instantiated_struct)),
+    );
+
+    // Update the scope to contain the newly added structure.
+    add_struct_to_scope(&pkg.structs[instantiated_name], scope.get_package_scope());
+    new_type_ref
+}
+
+fn instantiate_choice(
+    pkg: &mut ZPackage,
+    scope: &mut ModelScope,
+    z_choice: &ZChoice,
+    template_arguments: &Vec<Box<TypeReference>>,
+    instantiated_name: &String,
+) -> TypeReference {
+    assert!(z_choice.template_parameters.len() > 0);
+    assert!(z_choice.template_parameters.len() == template_arguments.len());
+
+    let new_type_ref = TypeReference {
+        is_builtin: false,
+        package: pkg.name.clone(),
+        name: instantiated_name.clone(),
+        bits: 0,
+        template_arguments: vec![],
+        type_arguments: vec![],
+        length_expression: None,
+    };
+
+    if pkg.zchoices.contains_key(instantiated_name) {
+        // The structure was already instantiated, there is no need to instantiate it again.
+        // Return a new reference to the already existing type.
+        return new_type_ref;
+    }
+
+    // The instantiated struct doesn't exist yet. Start by instantiating the
+    // template parameter itself.
+    let mut instantiated_types: HashMap<String, TypeReference> = HashMap::new();
+    for (index, template_arg) in template_arguments.iter().enumerate() {
+        // In case the type instantiation is a template itself, it must be instantiated
+        // before mapping it. In case the template argument itself is not a template,
+        // instantiate_type() will just pass the type through.
+        let instantiated_type = instantiate_type(pkg, scope, template_arg, "");
+        instantiated_types.insert(
+            z_choice.template_parameters[index].clone(),
+            instantiated_type,
+        );
+    }
+
+    let mut instantiated_choice = ZChoice {
+        name: instantiated_name.clone(),
+        template_parameters: vec![],
+        type_parameters: vec![],
+        selector_expression: z_choice.selector_expression.clone(),
+        cases: vec![],
+        default_case: None,
+        functions: vec![],
+    };
+
+    // Instantiate the choice fields
+    for case in &z_choice.cases {
+        instantiated_choice.cases.push(ZChoiceCase {
+            conditions: case.conditions.clone(),
+            field: {
+                if let Some(field) = &case.field {
+                    Option::from(Box::from(instantiate_field(
+                        pkg,
+                        scope,
+                        field,
+                        &instantiated_types,
+                    )))
+                } else {
+                    None
+                }
+            },
+        });
+    }
+    // Instantiate the default field, if present
+    if let Some(default_case) = &z_choice.default_case {
+        instantiated_choice.default_case = Option::from(ZChoiceCase {
+            conditions: default_case.conditions.clone(),
+            field: {
+                if let Some(field) = &default_case.field {
+                    Option::from(Box::from(instantiate_field(
+                        pkg,
+                        scope,
+                        field,
+                        &instantiated_types,
+                    )))
+                } else {
+                    None
+                }
+            },
+        });
+    }
+
+    // Instantiate the parameters
+    for rc_param in &z_choice.type_parameters {
+        // Check if the parameter is a templated type
+        let param = rc_param.as_ref().borrow();
+        if instantiated_types.contains_key(&param.name) {
+            // The parameter is a templated type, so replace the parameter
+            // type by a reference to the newly instantiated type.
+            instantiated_choice
+                .type_parameters
+                .push(Rc::new(RefCell::new(Parameter {
+                    name: param.name.clone(),
+                    zserio_type: Box::new(instantiated_types[&param.name].clone()),
+                })));
+        } else {
+            // The parameter is not templated, and is not affected by template instantiation.
+            instantiated_choice
+                .type_parameters
+                .push(Rc::new(RefCell::new(param.clone())));
+        }
+    }
+
+    // Add the newly added choice to the package.
+    pkg.zchoices.insert(
+        instantiated_name.clone(),
+        Rc::from(RefCell::from(instantiated_choice)),
+    );
+
+    // Update the scope to contain the newly added structure.
+    add_choice_to_scope(&pkg.zchoices[instantiated_name], scope.get_package_scope());
+    new_type_ref
+}
+
+pub fn instantiate_field(
+    pkg: &mut ZPackage,
+    scope: &mut ModelScope,
+    field: &Field,
+    instantiated_types: &HashMap<String, TypeReference>,
+) -> Field {
+    let mut new_field = field.clone();
+    if new_field.field_type.template_arguments.len() > 0 {
+        // The field type is not a template type itself, but by itself is a template,
+        // which is using the template type in its template parameters.
+        // For example:
+        // SomeOtherTemplate<TEMPLATE_TYPE> field;
+
+        // Iterate over the teamplate parameters and instantiate them.
+        let mut new_template_arguments = vec![];
+
+        for (index, template_parameter) in
+            new_field.field_type.template_arguments.iter().enumerate()
+        {
+            if instantiated_types.contains_key(&template_parameter.name) {
+                new_template_arguments.push(Box::from(
+                    instantiated_types[&template_parameter.name].clone(),
+                ));
+            } else {
+                new_template_arguments.push(template_parameter.clone());
+            }
+        }
+        new_field.field_type.template_arguments = new_template_arguments;
+
+        new_field.field_type = Box::from(instantiate_type(pkg, scope, &*new_field.field_type, ""));
+        return new_field;
+    }
+
+    // Check if the field type is directly a templated type. For example:
+    // TEMPLATE_TYPE field;
+    if instantiated_types.contains_key(&field.field_type.name) {
+        new_field.field_type = Box::from(instantiated_types[&field.field_type.name].clone());
+    }
+    return new_field;
+}

--- a/src/internal/generator/model.rs
+++ b/src/internal/generator/model.rs
@@ -3,7 +3,7 @@ use crate::internal::model::Model;
 use std::path::Path;
 
 pub fn generate_model(model: &Model, target_directory: &Path, _root_package: &str) {
-    for package in &model.packages {
+    for package in model.packages.values() {
         generate_package(package, target_directory);
     }
 }

--- a/src/internal/generator/package.rs
+++ b/src/internal/generator/package.rs
@@ -12,7 +12,7 @@ pub fn generate_package(package: &ZPackage, package_directory: &Path) {
     let mut module_names = Vec::new();
 
     // Generate  the rust code for zserio structures.
-    for z_struct_ref_cell in &package.structs {
+    for z_struct_ref_cell in package.structs.values() {
         let z_struct = z_struct_ref_cell.borrow();
         // ignore templates, only generate code for instantiated structs
         if !z_struct.template_parameters.is_empty() {
@@ -28,7 +28,7 @@ pub fn generate_package(package: &ZPackage, package_directory: &Path) {
     }
 
     // Generate  the rust code for zserio structures.
-    for z_choice_ref_cell in &package.zchoices {
+    for z_choice_ref_cell in package.zchoices.values() {
         let z_choice = z_choice_ref_cell.borrow();
         // Ignore templates, only generate code for instantiated choices.
         if !z_choice.template_parameters.is_empty() {

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -1,9 +1,8 @@
 use codegen::{Function, Scope};
 
-use crate::internal::ast::{zchoice::ZChoice, zchoice::ZChoiceCase};
+use crate::internal::ast::zchoice::ZChoice;
 
 use crate::internal::ast::field::Field;
-use crate::internal::generator::array::instantiate_zserio_arrays;
 
 use crate::internal::generator::{
     bitsize::bitsize_field, decode::decode_field, encode::encode_field,

--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -1,5 +1,3 @@
-use crate::internal::parser::gen::zserioparservisitor::ZserioParserVisitorCompat;
-
 use crate::internal::ast::package::{ZImport, ZPackage};
 use crate::internal::ast::type_reference::TypeReference;
 use crate::internal::ast::zconst::ZConst;
@@ -9,6 +7,8 @@ use crate::internal::ast::{
     type_reference::InstantiateType, zchoice::ZChoice, zchoice::ZChoiceCase, zfunction::ZFunction,
     zsubtype::Subtype, zunion::ZUnion,
 };
+use crate::internal::parser::gen::zserioparservisitor::ZserioParserVisitorCompat;
+use std::collections::HashMap;
 
 use crate::internal::ast::{
     expression::{EvaluationState, Expression, ExpressionFlag, ExpressionType},
@@ -160,8 +160,8 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             name: package_name,
             comment: "".into(),
             imports: imports,
-            structs: vec![],
-            zchoices: vec![],
+            structs: HashMap::new(),
+            zchoices: HashMap::new(),
             zunions: vec![],
             enums: vec![],
             consts: vec![],
@@ -177,10 +177,12 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                     for ve in v {
                         match ve {
                             ZserioTreeReturnType::Structure(s) => {
-                                package.structs.push(Rc::new(RefCell::new(*s)))
+                                let name = s.name.clone();
+                                package.structs.insert(name, Rc::new(RefCell::new(*s)));
                             }
                             ZserioTreeReturnType::Choice(c) => {
-                                package.zchoices.push(Rc::new(RefCell::new(*c)))
+                                let name = c.name.clone();
+                                package.zchoices.insert(name, Rc::new(RefCell::new(*c)));
                             }
                             ZserioTreeReturnType::Enumeration(e) => {
                                 package.enums.push(Rc::new(RefCell::new(*e)))

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -1,5 +1,7 @@
 pub mod reference_modules {
     pub mod core {
+        pub mod instantiations;
+        pub mod templates;
         pub mod types;
     }
 }
@@ -9,6 +11,7 @@ use crate::reference_modules::core::types::{
 };
 
 use bitreader::BitReader;
+use reference_modules::core::instantiations::instantiated_template_struct;
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableOject;
 
@@ -16,6 +19,7 @@ fn main() {
     test_structure();
     test_functions();
     test_choice();
+    test_template_instantiation();
 }
 
 fn test_structure() {
@@ -96,4 +100,24 @@ fn test_choice() {
     other_bitwriter.close().expect("failed to close bit stream");
     let other_serialized_bytes = other_bitwriter.data();
     assert!(other_serialized_bytes == serialized_bytes);
+}
+
+fn test_template_instantiation() {
+    // This function tests that templates can be successfully instantiated, and their
+    // generated types can be serialized and deserialized.
+    let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
+    z_struct.field.description = "Test Description".into();
+
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    z_struct.zserio_write(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_struct.zserio_read(&mut bitreader);
+
+    assert!(other_struct.field.description == z_struct.field.description);
 }


### PR DESCRIPTION
This commit adds support for template instantiations:
- it will parse all instantiations using the instantiate() keyword, pass the template parameters, matches them with the template arguments, and the resolves the content of the type.
- Type instantiations works with structs and choices, and replace all template types with their instantiated types.
- The test case has been enhanced to also process templated types.

So far, the current implementation does not yet support function template instantiation, which is still an open item.