### PR TITLE
Add Support for varint, varintxx, varuint, varsize zserio types

### DIFF
--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -19,11 +19,18 @@ pub fn get_array_trait_for_type(zserio_type: &TypeReference) -> String {
             "int16" => "BitFieldArrayTrait".into(),
             "int32" => "BitFieldArrayTrait".into(),
             "int64" => "BitFieldArrayTrait".into(),
-            "varint32" => "VarUintArrayTrait".into(),
+            "varint16" => "VarInt16ArrayTrait".into(),
+            "varint32" => "VarInt32ArrayTrait".into(),
+            "varint64" => "VarInt64ArrayTrait".into(),
+            "varint" => "VarIntArrayTrait".into(),
             "uint8" => "UnsignedBitFieldArrayTrait".into(),
             "uint16" => "UnsignedBitFieldArrayTrait".into(),
             "uint32" => "UnsignedBitFieldArrayTrait".into(),
+            "varuint16" => "VarUint16ArrayTrait".into(),
             "varuint32" => "VarUint32ArrayTrait".into(),
+            "varuint64" => "VarUint64ArrayTrait".into(),
+            "varuint" => "VarUintArrayTrait".into(),
+            "varsize" => "VarSizeArrayTrait".into(),
             "string" => "StringArrayTrait".into(),
             "float16" => "F16ArrayTrait".into(),
             "float32" => "F32ArrayTrait".into(),
@@ -32,7 +39,7 @@ pub fn get_array_trait_for_type(zserio_type: &TypeReference) -> String {
             "bit" => "UnsignedBitFieldArrayTrait".into(),
             "int" => "BitFieldArrayTrait".into(),
             "extern" => "ObjectArrayTrait".into(),
-            _ => panic!("failed to identify array trait"),
+            _ => panic!("failed to identify array trait {:?}", &zserio_type.name),
         }
     }
 }

--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -38,6 +38,8 @@ pub fn bitsize_type_reference(
         } else if type_reference.name == "bool" {
             // boolean
             function.line("end_position += 1;");
+        } else if type_reference.bits != 0 {
+            function.line(format!("end_position += {};", type_reference.bits));
         } else if let Some(node_idx) = context_node_index {
             // packed bitsize
             function.line(format!(
@@ -46,68 +48,52 @@ pub fn bitsize_type_reference(
                 initialize_array_trait(type_reference),
                 field_name,
             ));
-        } else if type_reference.bits != 0 {
-            function.line(format!("end_position += {};", type_reference.bits));
         } else {
-            if let Some(node_idx) = context_node_index {
-                // packed bitsize
-                function.line(format!(
-                    "end_position += context_node.children[{}].context.bitsize_of(&{}, end_position, &{});",
-                    node_idx,
-                    initialize_array_trait(&type_reference),
-                    field_name,
-                ));
-            } else {
-                if type_reference.bits != 0 {
-                    function.line(format!("end_position += {};", type_reference.bits));
-                } else {
-                    let bit_length = match type_reference.name.as_str() {
-                        "uint8" => String::from("8"),
-                        "uint16" => String::from("16"),
-                        "uint32" => String::from("32"),
-                        "uint64" => String::from("64"),
-                        "int8" => String::from("8"),
-                        "int16" => String::from("16"),
-                        "int32" => String::from("32"),
-                        "int64" => String::from("64"),
-                        "float16" => String::from("16"),
-                        "float32" => String::from("32"),
-                        "float64" => String::from("64"),
-                        "varint" => {
-                            format!("ztype::signed_bit_size({})", field_name)
-                        }
-                        "varint16" => {
-                            format!("ztype::signed_bit_size({})", field_name)
-                        }
-                        "varint32" => {
-                            format!("ztype::signed_bit_size({})", field_name)
-                        }
-                        "varint64" => {
-                            format!("ztype::signed_bit_size({})", field_name)
-                        }
-                        "varuint" => {
-                            format!("ztype::unsigned_bit_size({})", field_name)
-                        }
-                        "varuint16" => {
-                            format!("ztype::unsigned_bit_size({})", field_name)
-                        }
-                        "varuint32" => {
-                            format!("ztype::unsigned_bit_size({})", field_name)
-                        }
-                        "varuint64" => {
-                            format!("ztype::unsigned_bit_size({})", field_name)
-                        }
-                        "varsize" => {
-                            format!("ztype::unsigned_bit_size({})", field_name)
-                        }
-                        "int" | "bit" => {
-                            format!("{}", type_reference.bits)
-                        }
-                        _ => panic!("failed"),
-                    };
-                    function.line(format!("end_position += {};", bit_length,));
+            let bit_length = match type_reference.name.as_str() {
+                "uint8" => String::from("8"),
+                "uint16" => String::from("16"),
+                "uint32" => String::from("32"),
+                "uint64" => String::from("64"),
+                "int8" => String::from("8"),
+                "int16" => String::from("16"),
+                "int32" => String::from("32"),
+                "int64" => String::from("64"),
+                "float16" => String::from("16"),
+                "float32" => String::from("32"),
+                "float64" => String::from("64"),
+                "varint" => {
+                    format!("ztype::signed_bit_size({})", field_name)
                 }
-            }
+                "varint16" => {
+                    format!("ztype::signed_bit_size({})", field_name)
+                }
+                "varint32" => {
+                    format!("ztype::signed_bit_size({})", field_name)
+                }
+                "varint64" => {
+                    format!("ztype::signed_bit_size({})", field_name)
+                }
+                "varuint" => {
+                    format!("ztype::unsigned_bit_size({})", field_name)
+                }
+                "varuint16" => {
+                    format!("ztype::unsigned_bit_size({})", field_name)
+                }
+                "varuint32" => {
+                    format!("ztype::unsigned_bit_size({})", field_name)
+                }
+                "varuint64" => {
+                    format!("ztype::unsigned_bit_size({})", field_name)
+                }
+                "varsize" => {
+                    format!("ztype::unsigned_bit_size({})", field_name)
+                }
+                "int" | "bit" => {
+                    format!("{}", type_reference.bits)
+                }
+                _ => panic!("failed"),
+            };
+            function.line(format!("end_position += {};", bit_length,));
         }
     }
 }

--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -49,89 +49,64 @@ pub fn bitsize_type_reference(
         } else if type_reference.bits != 0 {
             function.line(format!("end_position += {};", type_reference.bits));
         } else {
-            match type_reference.name.as_str() {
-                "uint8" => {
-                    function.line("end_position += 8;");
+            if let Some(node_idx) = context_node_index {
+                // packed bitsize
+                function.line(format!(
+                    "end_position += context_node.children[{}].context.bitsize_of(&{}, end_position, &{});",
+                    node_idx,
+                    initialize_array_trait(&type_reference),
+                    field_name,
+                ));
+            } else {
+                if type_reference.bits != 0 {
+                    function.line(format!("end_position += {};", type_reference.bits));
+                } else {
+                    let bit_length = match type_reference.name.as_str() {
+                        "uint8" => String::from("8"),
+                        "uint16" => String::from("16"),
+                        "uint32" => String::from("32"),
+                        "uint64" => String::from("64"),
+                        "int8" => String::from("8"),
+                        "int16" => String::from("16"),
+                        "int32" => String::from("32"),
+                        "int64" => String::from("64"),
+                        "float16" => String::from("16"),
+                        "float32" => String::from("32"),
+                        "float64" => String::from("64"),
+                        "varint" => {
+                            format!("ztype::signed_bit_size({})", field_name)
+                        }
+                        "varint16" => {
+                            format!("ztype::signed_bit_size({})", field_name)
+                        }
+                        "varint32" => {
+                            format!("ztype::signed_bit_size({})", field_name)
+                        }
+                        "varint64" => {
+                            format!("ztype::signed_bit_size({})", field_name)
+                        }
+                        "varuint" => {
+                            format!("ztype::unsigned_bit_size({})", field_name)
+                        }
+                        "varuint16" => {
+                            format!("ztype::unsigned_bit_size({})", field_name)
+                        }
+                        "varuint32" => {
+                            format!("ztype::unsigned_bit_size({})", field_name)
+                        }
+                        "varuint64" => {
+                            format!("ztype::unsigned_bit_size({})", field_name)
+                        }
+                        "varsize" => {
+                            format!("ztype::unsigned_bit_size({})", field_name)
+                        }
+                        "int" | "bit" => {
+                            format!("{}", type_reference.bits)
+                        }
+                        _ => panic!("failed"),
+                    };
+                    function.line(format!("end_position += {};", bit_length,));
                 }
-                "uint16" => {
-                    function.line("end_position += 16;");
-                }
-                "uint32" => {
-                    function.line("end_position += 32;");
-                }
-                "uint64" => {
-                    function.line("end_position += 64;");
-                }
-                "int8" => {
-                    function.line("end_position += 8;");
-                }
-                "int16" => {
-                    function.line("end_position += 16;");
-                }
-                "int32" => {
-                    function.line("end_position += 32;");
-                }
-                "int64" => {
-                    function.line("end_position += 64;");
-                }
-                "float16" => {
-                    function.line("end_position += 16;");
-                }
-                "float32" => {
-                    function.line("end_position += 32;");
-                }
-                "float64" => {
-                    function.line("end_position += 64;");
-                }
-                "varint" => {
-                    function.line(format!(
-                        "end_position += ztype::signed_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varint16" => {
-                    function.line(format!(
-                        "end_position += ztype::signed_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varint32" => {
-                    function.line(format!(
-                        "end_position += ztype::signed_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varint64" => {
-                    function.line(format!(
-                        "end_position += ztype::signed_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varuint" => {
-                    function.line(format!(
-                        "end_position += ztype::unsigned_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varuint16" => {
-                    function.line(format!(
-                        "end_position += ztype::unsigned_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varuint32" => {
-                    function.line(format!(
-                        "end_position += ztype::unsigned_bit_size({});",
-                        field_name
-                    ));
-                }
-                "varuint64" => {
-                    function.line(format!(
-                        "end_position += ztype::unsigned_bit_size({});",
-                        field_name
-                    ));
-                }
-                _ => panic!("failed"),
             }
         }
     }

--- a/src/internal/generator/types.rs
+++ b/src/internal/generator/types.rs
@@ -31,7 +31,8 @@ pub fn convert_to_function_name(name: &String) -> String {
 pub fn ztype_to_rust_type(ztype: &TypeReference) -> String {
     if ztype.is_builtin {
         // the type is a zserio built-in type, such as int32, string, bool
-        return zserio_to_rust_type(&ztype.name).expect("type mapping failed");
+        return zserio_to_rust_type(&ztype.name)
+            .expect(format!("type mapping failed {:?}", &ztype.name).as_str());
     }
     // the type is a custom type, defined in some zserio file.
     custom_type_to_rust_type(&ztype.name)
@@ -47,11 +48,18 @@ pub fn zserio_to_rust_type(name: &str) -> Result<String, &'static str> {
         "int16" => Ok("i16".into()),
         "int32" => Ok("i32".into()),
         "int64" => Ok("i64".into()),
+        "varint16" => Ok("i16".into()),
         "varint32" => Ok("i32".into()),
+        "varint64" => Ok("i64".into()),
+        "varint" => Ok("i64".into()),
         "uint8" => Ok("u8".into()),
         "uint16" => Ok("u16".into()),
         "uint32" => Ok("u32".into()),
+        "varuint16" => Ok("u16".into()),
         "varuint32" => Ok("u32".into()),
+        "varuint64" => Ok("u64".into()),
+        "varsize" => Ok("u32".into()),
+        "varuint" => Ok("u64".into()),
         "string" => Ok("String".into()),
         "float16" => Ok("f32".into()),
         "float32" => Ok("f32".into()),

--- a/src/internal/generator/types.rs
+++ b/src/internal/generator/types.rs
@@ -32,7 +32,7 @@ pub fn ztype_to_rust_type(ztype: &TypeReference) -> String {
     if ztype.is_builtin {
         // the type is a zserio built-in type, such as int32, string, bool
         return zserio_to_rust_type(&ztype.name)
-            .expect(format!("type mapping failed {:?}", &ztype.name).as_str());
+            .unwrap_or_else(|_| panic!("type mapping failed {:?}", &ztype.name));
     }
     // the type is a custom type, defined in some zserio file.
     custom_type_to_rust_type(&ztype.name)


### PR DESCRIPTION
- These types were not yet supported during code generation, and would cause a panic during parsing files using these internal data types.