### PR TITLE
Fix swapping of package/typename during Type parsing

### DIFF
--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -1358,7 +1358,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
         };
         let mut package = "".into();
         if name.contains('.') {
-            let (new_name, new_package) = name.rsplit_once('.').unwrap();
+            let (new_package, new_name) = name.rsplit_once('.').unwrap();
             package = new_package.into();
             name = new_name.into();
         }


### PR DESCRIPTION
- the name and the package path of a type were swapped, causing issues when looking up a type.