### PR TITLE
Implement better Error logging when code formatting fails

### DIFF
--- a/src/internal/generator/file_generator.rs
+++ b/src/internal/generator/file_generator.rs
@@ -4,9 +4,15 @@ use std::io::Write;
 use std::path::Path;
 
 pub fn write_to_file(content: &String, root_path: &Path, zserio_pkg_name: &str, file_name: &str) {
-    let formatted_code = RustFmt::default()
-        .format_str(content)
-        .expect("code formatting failed");
+    let format_result = RustFmt::default().format_str(content);
+    if format_result.is_err() {
+        panic!(
+            "code formatting failed: error {:?}, content {:?}",
+            format_result.err(),
+            content
+        );
+    }
+    let formatted_code = format_result.unwrap();
     let file_bytes = formatted_code.as_bytes();
 
     let mut file_path = root_path.to_owned();


### PR DESCRIPTION
- Due to debugger limitations, if code formatting fails, the error message would only print out the start of the code of the file it tried to format. The majority of  the file would be swallowed, making it difficult to debug what is actually wrong in the generated file.
- This commit improves this by dumping the entire unformatted file for debug purpose, plus adding the error information.