### PR TITLE
Change Array Decoding to instantiate the array elements earlier

### DIFF
--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -31,6 +31,7 @@ pub fn generate_choice(
     // generate the ZChoice as a rust structure
     let gen_choice = codegen_scope.new_struct(&rust_type_name);
     gen_choice.vis("pub");
+    gen_choice.derive("Clone");
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zchoice.type_parameters {

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -24,8 +24,8 @@ pub fn generate_enum(
     // generate the struct itself
     let gen_enum = gen_scope.new_enum(&rust_type_name);
     gen_enum.vis("pub");
-    gen_enum.derive("Copy");
     gen_enum.derive("Clone");
+    gen_enum.derive("Copy");
     gen_enum.derive("PartialEq");
 
     let mut enum_value = 0;
@@ -100,18 +100,16 @@ pub fn generate_enum(
 
 fn generate_zserio_read(scope: &ModelScope, struct_impl: &mut codegen::Impl, zenum: &ZEnum) {
     let rust_type_name = to_rust_type_name(&zenum.name);
-    let temp_var = format!(
-        "let v: {}",
-        zserio_to_rust_type(zenum.enum_type.name.as_str()).unwrap()
-    );
-
     let zserio_read_fn = struct_impl.new_fn("zserio_read");
     zserio_read_fn.arg_mut_self();
     zserio_read_fn.arg("reader", "&mut BitReader");
     decode_type(
         scope,
         zserio_read_fn,
-        &temp_var,
+        &format!(
+            "let v: {}",
+            zserio_to_rust_type(zenum.enum_type.name.as_str()).unwrap()
+        ),
         &String::from(""),
         &zenum.enum_type,
         None,
@@ -122,11 +120,15 @@ fn generate_zserio_read(scope: &ModelScope, struct_impl: &mut codegen::Impl, zen
     zserio_read_packed_fn.arg_mut_self();
     zserio_read_packed_fn.arg("context_node", "&mut PackingContextNode");
     zserio_read_packed_fn.arg("reader", "&mut BitReader");
+    zserio_read_packed_fn.line(format!(
+        "let mut v: {} = 0;",
+        zserio_to_rust_type(zenum.enum_type.name.as_str()).unwrap()
+    ));
     decode_type(
         scope,
         zserio_read_packed_fn,
-        &temp_var,
         &String::from(""),
+        &String::from("v"),
         &zenum.enum_type,
         Option::from(0),
     );

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -44,6 +44,7 @@ pub fn generate_struct(
     // generate the struct itself
     let gen_struct = codegen_scope.new_struct(&rust_type_name);
     gen_struct.vis("pub");
+    gen_struct.derive("Clone");
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zstruct.type_parameters {

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -77,6 +77,7 @@ pub fn generate_union(
     // generate the union itself
     let gen_union = codegen_scope.new_struct(&rust_type_name);
     gen_union.vis("pub");
+    gen_union.derive("Clone");
 
     // if the union is parameterized, add the parameters as struct fields
     for param in &zunion.type_parameters {

--- a/src/ztype/array_traits/array_trait.rs
+++ b/src/ztype/array_traits/array_trait.rs
@@ -6,7 +6,7 @@ pub trait ArrayTrait<T> {
     fn needs_bitsizeof_position(&self) -> bool;
     fn bitsize_of(&self, bit_position: u64, value: &T) -> u64;
     fn initialize_offsets(&self, bit_position: u64, value: &T) -> u64;
-    fn read(&self, reader: &mut BitReader) -> T;
+    fn read(&self, reader: &mut BitReader, value: &mut T, index: usize);
     fn write(&self, writer: &mut BitWriter, value: &T);
     fn to_u64(&self, value: &T) -> u64;
     #[allow(clippy::wrong_self_convention)]
@@ -32,7 +32,13 @@ pub trait ArrayTrait<T> {
         element: &T,
     ) -> u64;
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> T;
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut T,
+        index: usize,
+    );
 
     fn write_packed(
         &self,

--- a/src/ztype/array_traits/bit_field_array_trait.rs
+++ b/src/ztype/array_traits/bit_field_array_trait.rs
@@ -30,8 +30,8 @@ impl array_trait::ArrayTrait<name> for BitFieldArrayTrait {
         bit_position + self.bitsize_of(bit_position, &0)
     }
 
-    fn read(&self, reader: &mut BitReader) -> name {
-        read_signed_bits(reader, self.bitsize_of(0, &0) as u8) as name
+    fn read(&self, reader: &mut BitReader, value: &mut name, _index: usize) {
+        *value = read_signed_bits(reader, self.bitsize_of(0, &0) as u8) as name;
     }
 
     fn write(&self, writer: &mut BitWriter, value: &name) {
@@ -67,8 +67,14 @@ impl array_trait::ArrayTrait<name> for BitFieldArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> name {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut name,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/float16_array_trait.rs
+++ b/src/ztype/array_traits/float16_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<f32> for Float16ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> f32 {
-        ztype::read_f16(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut f32, _index: usize) {
+        *value = ztype::read_f16(reader)
     }
 
     fn write(&self, writer: &mut BitWriter, value: &f32) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<f32> for Float16ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> f32 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut f32,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/float32_array_trait.rs
+++ b/src/ztype/array_traits/float32_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<f32> for Float32ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> f32 {
-        ztype::read_f32(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut f32, _index: usize) {
+        *value = ztype::read_f32(reader)
     }
 
     fn write(&self, writer: &mut BitWriter, value: &f32) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<f32> for Float32ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> f32 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut f32,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/float64_array_trait.rs
+++ b/src/ztype/array_traits/float64_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<f64> for Float64ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> f64 {
-        ztype::read_f64(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut f64, _index: usize) {
+        *value = ztype::read_f64(reader)
     }
 
     fn write(&self, writer: &mut BitWriter, value: &f64) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<f64> for Float64ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> f64 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut f64,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/object_array_trait.rs
+++ b/src/ztype/array_traits/object_array_trait.rs
@@ -27,10 +27,8 @@ where
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> T {
-        let mut value = T::new();
+    fn read(&self, reader: &mut BitReader, value: &mut T, _index: usize) {
         value.zserio_read(reader);
-        value
     }
 
     fn write(&self, writer: &mut BitWriter, value: &T) {
@@ -66,10 +64,14 @@ where
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> T {
-        let mut element = T::new();
-        element.zserio_read_packed(context_node, reader);
-        element
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut T,
+        _index: usize,
+    ) {
+        value.zserio_read_packed(context_node, reader);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/string_array_trait.rs
+++ b/src/ztype/array_traits/string_array_trait.rs
@@ -25,8 +25,8 @@ impl array_trait::ArrayTrait<String> for StringArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> String {
-        read_string(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut String, _index: usize) {
+        *value = read_string(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &String) {
@@ -61,8 +61,14 @@ impl array_trait::ArrayTrait<String> for StringArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> String {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut String,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/unsigned_bit_field_array_trait.rs
+++ b/src/ztype/array_traits/unsigned_bit_field_array_trait.rs
@@ -30,8 +30,8 @@ impl array_trait::ArrayTrait<name> for UnsignedBitFieldArrayTrait {
         bit_position + self.bitsize_of(bit_position, &0u8)
     }
 
-    fn read(&self, reader: &mut BitReader) -> name {
-        read_unsigned_bits(reader, self.bitsize_of(0, &0u8) as u8) as name
+    fn read(&self, reader: &mut BitReader, value: &mut name, _index: usize) {
+        *value = read_unsigned_bits(reader, self.bitsize_of(0, &0u8) as u8) as name;
     }
 
     fn write(&self, writer: &mut BitWriter, value: &name) {
@@ -67,8 +67,14 @@ impl array_trait::ArrayTrait<name> for UnsignedBitFieldArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> name {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut name,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varint16_array_trait.rs
+++ b/src/ztype/array_traits/varint16_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<i16> for VarInt16ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> i16 {
-        ztype::read_varint16(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut i16, _index: usize) {
+        *value = ztype::read_varint16(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &i16) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<i16> for VarInt16ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> i16 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut i16,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varint32_array_trait.rs
+++ b/src/ztype/array_traits/varint32_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<i32> for VarInt32ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> i32 {
-        ztype::read_varint32(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut i32, _index: usize) {
+        *value = ztype::read_varint32(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &i32) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<i32> for VarInt32ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> i32 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut i32,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varint64_array_trait.rs
+++ b/src/ztype/array_traits/varint64_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<i64> for VarInt64ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> i64 {
-        ztype::read_varint64(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut i64, _index: usize) {
+        *value = ztype::read_varint64(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &i64) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<i64> for VarInt64ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> i64 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut i64,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varint_array_trait.rs
+++ b/src/ztype/array_traits/varint_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<i64> for VarIntArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> i64 {
-        ztype::read_varint(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut i64, _index: usize) {
+        *value = ztype::read_varint(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &i64) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<i64> for VarIntArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> i64 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut i64,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varsize_array_trait.rs
+++ b/src/ztype/array_traits/varsize_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<u32> for VarSizeArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> u32 {
-        ztype::read_varsize(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut u32, _index: usize) {
+        *value = ztype::read_varsize(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &u32) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<u32> for VarSizeArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> u32 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut u32,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varuint16_array_trait.rs
+++ b/src/ztype/array_traits/varuint16_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<u16> for VarUint16ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> u16 {
-        ztype::read_varuint16(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut u16, _index: usize) {
+        *value = ztype::read_varuint16(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &u16) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<u16> for VarUint16ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> u16 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut u16,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varuint32_array_trait.rs
+++ b/src/ztype/array_traits/varuint32_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<u32> for VarUint32ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> u32 {
-        ztype::read_varuint32(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut u32, _index: usize) {
+        *value = ztype::read_varuint32(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &u32) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<u32> for VarUint32ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> u32 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut u32,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varuint64_array_trait.rs
+++ b/src/ztype/array_traits/varuint64_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<u64> for VarUint64ArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> u64 {
-        ztype::read_varuint64(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut u64, _index: usize) {
+        *value = ztype::read_varuint64(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &u64) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<u64> for VarUint64ArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> u64 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut u64,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/array_traits/varuint_array_trait.rs
+++ b/src/ztype/array_traits/varuint_array_trait.rs
@@ -23,8 +23,8 @@ impl array_trait::ArrayTrait<u64> for VarUintArrayTrait {
         bit_position + self.bitsize_of(bit_position, value)
     }
 
-    fn read(&self, reader: &mut BitReader) -> u64 {
-        ztype::read_varuint(reader)
+    fn read(&self, reader: &mut BitReader, value: &mut u64, _index: usize) {
+        *value = ztype::read_varuint(reader);
     }
 
     fn write(&self, writer: &mut BitWriter, value: &u64) {
@@ -60,8 +60,14 @@ impl array_trait::ArrayTrait<u64> for VarUintArrayTrait {
         bit_position + context_node.context.bitsize_of(self, bit_position, element)
     }
 
-    fn read_packed(&self, context_node: &mut PackingContextNode, reader: &mut BitReader) -> u64 {
-        context_node.context.read(self, reader)
+    fn read_packed(
+        &self,
+        context_node: &mut PackingContextNode,
+        reader: &mut BitReader,
+        value: &mut u64,
+        index: usize,
+    ) {
+        context_node.context.read(self, reader, value, index);
     }
 
     fn write_packed(

--- a/src/ztype/bytes_type.rs
+++ b/src/ztype/bytes_type.rs
@@ -4,7 +4,7 @@ use crate::ztype::{read_varsize, write_varsize};
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct BytesType {
     pub byte_size: u32,
     pub data_blob: Vec<u8>,

--- a/src/ztype/extern_type.rs
+++ b/src/ztype/extern_type.rs
@@ -4,7 +4,7 @@ use crate::ztype::{read_varsize, write_varsize};
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct ExternType {
     pub bit_size: u32,
     pub data_blob: Vec<u8>,


### PR DESCRIPTION
- In the old code, when deserializing an array, the (generic) array code would instantiate the object, then deserialize the data into it, and then return it.
- This will cause problems when the array is parameterized, for example by using the `@index` operator. In that case, each array element needs to have custom parameters, that need to be passed to the array decoding logic.
- This is extremely difficult to do, since the array code is written using generics, and does not support passing different parameters for every different type.
- To resolve this efficiently, the array decoding is broken up.

The new code works as follows:
1) The generated (specific) code reads the array length. 2) Within the same code, the array elements are initialized (empty). 3) The paramters are passed to the array element created in step 2.
   Since this code is still in the specific generated code, this parameter
   passing can be easily generated.
4) The generic code is called, to deserialize the data. Since each
   array element comes pre-instantiated and already has all parameters
   passed, the generic code doesn't have to deal with that.

There are other solutions that I have experimented with before, which involves keeping a copy of each array element in the array traits, but that doesn't seemed to be a very elegant solution.

The current code should be more readable with good performance.