### PR TITLE
Implement Support for Parameter Passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 antlr-rust = "0.3.0-beta"
-bitreader = "0.3.6"
+bitreader = { git = "https://github.com/Danaozhong/bitreader", branch = "Bug/FixLeftShiftWithOverflowException" }
 bitstream-io = "1.6.0"
 clap = { version="4.2.7", features = [ "derive" ] }
 codegen = "0.2.0"
@@ -24,6 +24,6 @@ half = "2.3.1"
 num = "0.4.0"
 proc-macro2 = "1.0.66"
 rstest = "0.16.0"
-rust-bitwriter = { git = "https://github.com/Danaozhong/rust-bitwriter", version = "0.0.1" }
+rust-bitwriter = { git = "https://github.com/Danaozhong/rust-bitwriter.git", branch = "main" }
 rust-format = "0.3.4"
 walkdir = "2.3.2"

--- a/src/internal/ast/field.rs
+++ b/src/internal/ast/field.rs
@@ -27,5 +27,10 @@ pub struct Field {
 impl Field {
     pub fn evaluate(&self, scope: &mut ModelScope) {
         self.field_type.evaluate(scope);
+        if let Some(array) = &self.array {
+            if let Some(array_length_expression) = &array.array_length_expression {
+                array_length_expression.borrow_mut().evaluate(scope);
+            }
+        }
     }
 }

--- a/src/internal/compiler/fundamental_type.rs
+++ b/src/internal/compiler/fundamental_type.rs
@@ -35,7 +35,7 @@ pub fn get_fundamental_type(
                 symbol_name: current_symbol_ref,
             }
         ); */
-        current_type_ref = match current_symbol_ref.symbol {
+        let mut new_type_ref = match current_symbol_ref.symbol {
             Symbol::Bitmask(_)
             | Symbol::Choice(_)
             | Symbol::Enum(_)
@@ -48,6 +48,11 @@ pub fn get_fundamental_type(
             Symbol::Subtype(subtype) => *subtype.borrow().zserio_type.clone(),
             _ => panic!("unexpected type {:?}", current_symbol_ref.symbol),
         };
+
+        // Make sure that the type arguments are passed to the
+        // fundamental type.
+        new_type_ref.type_arguments = current_type_ref.type_arguments.clone();
+        current_type_ref = new_type_ref;
 
         if is_marshaler {
             // If the type is a marshaller type, return the type reference

--- a/src/internal/generator.rs
+++ b/src/internal/generator.rs
@@ -8,6 +8,7 @@ pub mod function;
 pub mod model;
 pub mod new;
 pub mod package;
+pub mod pass_parameters;
 pub mod preamble;
 pub mod subtype;
 pub mod types;

--- a/src/internal/generator/decode.rs
+++ b/src/internal/generator/decode.rs
@@ -1,8 +1,15 @@
+use crate::internal::generator::expression::generate_expression;
+use crate::internal::generator::pass_parameters::{
+    does_expression_contains_index_operator, get_type_parameter,
+};
 use codegen::Function;
+
+
+
 
 use crate::internal::ast::{field::Field, type_reference::TypeReference};
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
-use crate::internal::compiler::symbol_scope::ModelScope;
+use crate::internal::compiler::symbol_scope::{ModelScope};
 use crate::internal::generator::new::get_default_initializer;
 use crate::internal::generator::types::{
     convert_field_name, zserio_to_rust_type, ztype_to_rust_type,
@@ -111,7 +118,7 @@ pub fn decode_field(
         function.line("if present {");
 
         // In case the field is optional, create a local variable
-        // to store the value temporarly.
+        // to store the value temporarily.
         if field.array.is_some() {
             field_type = format!("Vec<{}>", field_type.as_str());
         }
@@ -139,8 +146,8 @@ pub fn decode_field(
         rvalue_field_name = "optional_value".into();
     }
 
+    let array_type_name = array_type_name(&field.name);
     if field.array.is_some() {
-        let array_type_name = array_type_name(&field.name);
         // Array fields need to be serialized using the array class, which takes
         // care of the array delta compression.
 
@@ -163,9 +170,60 @@ pub fn decode_field(
             "{} = vec![{}; {}_array_length];",
             rvalue_field_name, default_value, field_name,
         ));
+    }
 
-        // TODO need to pass the parameters.
+    // Pass the parameters.
+    if !native_type.fundamental_type.type_arguments.is_empty() {
+        let type_parameters = get_type_parameter(scope, &native_type.fundamental_type);
 
+        // Check if parameters are passed to an array. If yes, a for loop is required.
+        let mut element_name = rvalue_field_name.clone();
+
+        if field.array.is_some() {
+            element_name = String::from("element");
+            let mut parameter_passing_uses_index_operator = false;
+            for type_param in &native_type.fundamental_type.type_arguments {
+                if does_expression_contains_index_operator(&type_param.borrow()) {
+                    parameter_passing_uses_index_operator = true;
+                    break;
+                }
+            }
+            // Depending on if the @index operator is used, the for loop need an index variable,
+            // to be able to assign the parameters to the correct index.
+            if parameter_passing_uses_index_operator {
+                function.line(format!(
+                    "for (param_index, element) in {}.iter_mut().enumerate() {{",
+                    rvalue_field_name
+                ));
+            } else {
+                function.line(format!("for element in &mut {} {{", rvalue_field_name));
+            }
+        }
+
+        for (param_index, type_argument_rc) in native_type
+            .fundamental_type
+            .type_arguments
+            .iter()
+            .enumerate()
+        {
+            let type_argument = type_argument_rc.borrow();
+            let type_parameter = &type_parameters[param_index];
+
+            function.line(format!(
+                "{}.{} = {}.clone();",
+                element_name,
+                convert_field_name(&type_parameter.borrow().name),
+                generate_expression(&type_argument),
+            ));
+        }
+
+        if field.array.is_some() {
+            // Close the for-loop used to pass the parameters to the array elements.
+            function.line("}");
+        }
+    }
+
+    if field.array.is_some() {
         function.line(format!(
             "{}.zserio_read(reader, &mut {});",
             array_type_name, rvalue_field_name,

--- a/src/internal/generator/decode.rs
+++ b/src/internal/generator/decode.rs
@@ -4,12 +4,9 @@ use crate::internal::generator::pass_parameters::{
 };
 use codegen::Function;
 
-
-
-
 use crate::internal::ast::{field::Field, type_reference::TypeReference};
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
-use crate::internal::compiler::symbol_scope::{ModelScope};
+use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::new::get_default_initializer;
 use crate::internal::generator::types::{
     convert_field_name, zserio_to_rust_type, ztype_to_rust_type,

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -7,9 +7,9 @@ use crate::internal::generator::types::{
 };
 use crate::internal::parser::gen::zserioparser::{
     AND, BANG, BINARY_LITERAL, BOOL_LITERAL, DECIMAL_LITERAL, DIVIDE, DOT, DOUBLE_LITERAL, EQ,
-    FLOAT_LITERAL, GE, GT, HEXADECIMAL_LITERAL, ID, LE, LENGTHOF, LOGICAL_AND, LOGICAL_OR, LPAREN,
-    LSHIFT, LT, MINUS, MODULO, MULTIPLY, NE, NUMBITS, OCTAL_LITERAL, OR, PLUS, QUESTIONMARK,
-    RPAREN, RSHIFT, TILDE, VALUEOF, XOR,
+    FLOAT_LITERAL, GE, GT, HEXADECIMAL_LITERAL, ID, INDEX, LBRACKET, LE, LENGTHOF, LOGICAL_AND,
+    LOGICAL_OR, LPAREN, LSHIFT, LT, MINUS, MODULO, MULTIPLY, NE, NUMBITS, OCTAL_LITERAL, OR, PLUS,
+    QUESTIONMARK, RPAREN, RSHIFT, TILDE, VALUEOF, XOR,
 };
 
 pub struct ExpressionGenerationResult {
@@ -29,6 +29,7 @@ pub fn generate_expression(expression: &Expression) -> String {
             "{}()",
             generate_expression(expression.operand1.as_ref().unwrap())
         ),
+        LBRACKET => generate_bracketed_expression(expression),
         DOT => generate_dot_expression(expression),
         VALUEOF => generate_valueof_expression(expression),
         LENGTHOF => generate_lengthof_expression(expression),
@@ -43,6 +44,7 @@ pub fn generate_expression(expression: &Expression) -> String {
         ID => generate_identifier_expression(expression),
         BOOL_LITERAL | OCTAL_LITERAL | HEXADECIMAL_LITERAL | BINARY_LITERAL | DECIMAL_LITERAL
         | FLOAT_LITERAL | DOUBLE_LITERAL => generate_literal_expression(expression),
+        INDEX => generate_index_operator(),
         /*
         0xFFFFF => (), // Ignore
          */
@@ -79,6 +81,14 @@ fn generate_arithmetic_expression(expression: &Expression) -> String {
             MODULO => "%",
             _ => panic!("unexpected arithmetic expression operator"),
         },
+        generate_expression(expression.operand2.as_ref().unwrap()),
+    )
+}
+
+fn generate_bracketed_expression(expression: &Expression) -> String {
+    format!(
+        "{}[{}]",
+        generate_expression(expression.operand1.as_ref().unwrap()),
         generate_expression(expression.operand2.as_ref().unwrap()),
     )
 }
@@ -291,4 +301,10 @@ fn generate_literal_expression(expression: &Expression) -> String {
 
         _ => panic!("unexpected comparison expression operator"),
     }
+}
+
+fn generate_index_operator() -> String {
+    // Make sure this variable name matches the one used in encode/decode code generators
+    // where the parameters are passed.
+    "param_index".into()
 }

--- a/src/internal/generator/pass_parameters.rs
+++ b/src/internal/generator/pass_parameters.rs
@@ -1,0 +1,45 @@
+use crate::internal::ast::{
+    expression::Expression, parameter::Parameter, type_reference::TypeReference,
+};
+
+use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
+use crate::internal::parser::gen::zserioparser::INDEX;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub fn get_type_parameter(
+    scope: &ModelScope,
+    type_ref: &TypeReference,
+) -> Vec<Rc<RefCell<Parameter>>> {
+    let symbol = scope.get_symbol(type_ref);
+    return match symbol.symbol {
+        Symbol::Choice(zchoice) => zchoice.borrow().type_parameters.clone(),
+        Symbol::Struct(zstruct) => zstruct.borrow().type_parameters.clone(),
+        Symbol::Union(zunion) => zunion.borrow().type_parameters.clone(),
+        _ => panic!("type is not parameterizable"),
+    };
+}
+
+/// This function checks if an expression (or any sub-expression) contain an @index operator.
+pub fn does_expression_contains_index_operator(expression: &Expression) -> bool {
+    let mut expressions_to_check = vec![expression];
+
+    while let Some(current_exp) = expressions_to_check.pop() {
+        
+
+        if current_exp.expression_type == INDEX {
+            return true;
+        }
+        if let Some(op1) = &current_exp.operand1 {
+            expressions_to_check.push(op1);
+        }
+        if let Some(op2) = &current_exp.operand2 {
+            expressions_to_check.push(op2);
+        }
+        if let Some(op3) = &current_exp.operand3 {
+            expressions_to_check.push(op3);
+        }
+    }
+    // if none of the checked expressions contain the index operator, return false.
+    false
+}

--- a/src/internal/generator/pass_parameters.rs
+++ b/src/internal/generator/pass_parameters.rs
@@ -25,8 +25,6 @@ pub fn does_expression_contains_index_operator(expression: &Expression) -> bool 
     let mut expressions_to_check = vec![expression];
 
     while let Some(current_exp) = expressions_to_check.pop() {
-        
-
         if current_exp.expression_type == INDEX {
             return true;
         }

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -32,6 +32,7 @@ pub fn generate_choice(
     let gen_choice = codegen_scope.new_struct(&rust_type_name);
     gen_choice.vis("pub");
     gen_choice.derive("Clone");
+    gen_choice.derive("PartialEq");
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zchoice.type_parameters {

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -45,6 +45,7 @@ pub fn generate_struct(
     let gen_struct = codegen_scope.new_struct(&rust_type_name);
     gen_struct.vis("pub");
     gen_struct.derive("Clone");
+    gen_struct.derive("PartialEq");
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zstruct.type_parameters {

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -47,6 +47,7 @@ pub fn generate_union(
     let union_selector_gen_scope = codegen_scope.new_enum(&selector_type_name);
     union_selector_gen_scope.derive("Copy");
     union_selector_gen_scope.derive("Clone");
+    union_selector_gen_scope.derive("PartialEq");
 
     union_selector_gen_scope.vis("pub");
     for (field_index, field) in zunion.fields.iter().enumerate() {
@@ -78,6 +79,7 @@ pub fn generate_union(
     let gen_union = codegen_scope.new_struct(&rust_type_name);
     gen_union.vis("pub");
     gen_union.derive("Clone");
+    gen_union.derive("PartialEq");
 
     // if the union is parameterized, add the parameters as struct fields
     for param in &zunion.type_parameters {

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -7,3 +7,5 @@ import reference_modules.user.testobject.*;
 import reference_modules.type_lookup_test.unrelated_ztype.*;
 import reference_modules.type_lookup_test.ztype.*;
 import reference_modules.type_lookup_test.other_ztype.*;
+import reference_modules.parameter_passing.index_operator.*;
+import reference_modules.parameter_passing.parameter_passing.*;

--- a/tests/reference_modules/core/types.zs
+++ b/tests/reference_modules/core/types.zs
@@ -29,7 +29,7 @@ struct ValueWrapper(int32 parameter)
     string description;
     optional int32 optInt32;
     
-    bit:10 fixed_array[128];
+    bit:10 fixed_array[4];
 
     string str_array[];
 

--- a/tests/reference_modules/parameter_passing/index_operator.zs
+++ b/tests/reference_modules/parameter_passing/index_operator.zs
@@ -1,0 +1,25 @@
+package reference_modules.parameter_passing.index_operator;
+
+// This is a simple test case to test the @index operator.
+struct IndexOperator
+{
+    uint16                  numBlocks;
+    BlockHeader             headers[numBlocks];
+
+    // Note: the headers are passed as element-by-element parameters to the blocks array.
+    Block(headers[@index])  blocks[numBlocks];
+};
+
+struct BlockHeader
+{
+    uint16 numItems;
+};
+
+struct Block(BlockHeader header)
+{
+    int64 items[header.numItems];
+
+    // Add a conditional item, that depends on the parameter passed in the index.
+    // This ensures that during serialization / deserialization, the item is correctly passed.
+    uint8 conditionItem if lengthof(items) > 0;
+};

--- a/tests/reference_modules/parameter_passing/parameter_passing.zs
+++ b/tests/reference_modules/parameter_passing/parameter_passing.zs
@@ -10,7 +10,7 @@ struct ParameterPassing
     Block(numElements)  block;
 
     // Test passing of parameters to an array.
-    Block(numElements) blocks[3];
+    Block(numElements) blocks[2];
 };
 
 struct Block(uint32 numElements)

--- a/tests/reference_modules/parameter_passing/parameter_passing.zs
+++ b/tests/reference_modules/parameter_passing/parameter_passing.zs
@@ -1,0 +1,23 @@
+package reference_modules.parameter_passing.parameter_passing;
+
+// This is a simple test case to test parameter passing.
+struct ParameterPassing
+{
+    uint16 numBlocks;
+    uint32 numElements;
+
+    // Test passing of parameters to a single instance.
+    Block(numElements)  block;
+
+    // Test passing of parameters to an array.
+    Block(numElements) blocks[3];
+};
+
+struct Block(uint32 numElements)
+{
+    int64 items[numElements];
+
+    // Add a conditional item, that depends on the parameter passed in the index.
+    // This ensures that during serialization / deserialization, the item is correctly passed.
+    uint8 conditionItem if lengthof(numElements) > 0;
+};

--- a/tests/round-trip-tests/Cargo.toml
+++ b/tests/round-trip-tests/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitreader = "0.3.7"
-rust-bitwriter = { git = "https://github.com/Danaozhong/rust-bitwriter.git", version = "0.0.1" }
+bitreader = { git = "https://github.com/Danaozhong/bitreader", branch = "Bug/FixLeftShiftWithOverflowException" }
+rust-bitwriter = { git = "https://github.com/Danaozhong/rust-bitwriter.git", branch = "main" }
 rust-zserio = { path = "../.." }
 
 [build-dependencies]

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -21,7 +21,6 @@ use crate::reference_modules::core::types::{
     value_wrapper,
 };
 
-
 use crate::reference_modules::type_lookup_test::ztype::union_type::{UnionType, UnionTypeSelector};
 use crate::reference_modules::type_lookup_test::ztype::z_type_struct::ZTypeStruct;
 

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -9,12 +9,19 @@ pub mod reference_modules {
         pub mod unrelated_ztype;
         pub mod ztype;
     }
+    pub mod parameter_passing {
+        pub mod index_operator;
+        pub mod parameter_passing;
+    }
 }
+pub mod parameter_passing_test;
 
 use crate::reference_modules::core::types::{
     basic_choice::BasicChoice, color::Color, extern_test_case::ExternTestCase, some_enum::SomeEnum,
     value_wrapper,
 };
+
+
 use crate::reference_modules::type_lookup_test::ztype::union_type::{UnionType, UnionTypeSelector};
 use crate::reference_modules::type_lookup_test::ztype::z_type_struct::ZTypeStruct;
 
@@ -23,6 +30,7 @@ use reference_modules::core::instantiations::instantiated_template_struct;
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableOject;
 
+use crate::parameter_passing_test::{test_index_operator, test_parameter_passing};
 fn main() {
     test_structure();
     test_functions();
@@ -32,6 +40,8 @@ fn main() {
     test_extern_type();
     test_type_lookup();
     test_union_type();
+    test_parameter_passing();
+    test_index_operator();
 }
 
 fn test_structure() {

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -128,6 +128,7 @@ fn test_template_instantiation() {
     // generated types can be serialized and deserialized.
     let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
     z_struct.field.description = "Test Description".into();
+    z_struct.field.fixed_array = vec![0, 1, 2, 3];
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -141,6 +142,7 @@ fn test_template_instantiation() {
     other_struct.zserio_read(&mut bitreader);
 
     assert!(other_struct.field.description == z_struct.field.description);
+    assert!(other_struct.field.fixed_array == z_struct.field.fixed_array);
 }
 
 fn test_functions_in_instantiated_templates() {

--- a/tests/round-trip-tests/src/parameter_passing_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_test.rs
@@ -1,4 +1,3 @@
-
 use crate::reference_modules::parameter_passing::parameter_passing::{
     block::Block, parameter_passing::ParameterPassing,
 };

--- a/tests/round-trip-tests/src/parameter_passing_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_test.rs
@@ -1,0 +1,59 @@
+
+use crate::reference_modules::parameter_passing::parameter_passing::{
+    block::Block, parameter_passing::ParameterPassing,
+};
+
+use bitreader::BitReader;
+use rust_bitwriter::BitWriter;
+use rust_zserio::ztype::ZserioPackableOject;
+
+pub fn test_parameter_passing() {
+    // Create a test structure, which uses parameter passing
+    let test_struct = ParameterPassing {
+        num_blocks: 2,
+        num_elements: 1, // This is the only true value for num_elements - will be passed over to all others.
+        block: Block {
+            num_elements: 1,
+            items: vec![10],    // should have one element, because num_elements = 1
+            condition_item: 15, // should be serialize, because num_elements > 0
+        },
+        blocks: vec![
+            Block {
+                num_elements: 1, // taken from the root struct, but still needs to be set
+                items: vec![11],
+                condition_item: 16,
+            },
+            Block {
+                num_elements: 1, // taken from the root struct, but still needs to be set
+                items: vec![15],
+                condition_item: 17,
+            },
+        ],
+    };
+
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    test_struct.zserio_write(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_test_struct = ParameterPassing::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct.zserio_read(&mut bitreader);
+
+    // expect them to be identical.
+    assert!(test_struct.num_elements == other_test_struct.num_elements);
+    assert!(test_struct.num_blocks == other_test_struct.num_blocks);
+    assert!(test_struct.block.condition_item == other_test_struct.block.condition_item);
+    assert!(test_struct.block.items == other_test_struct.block.items);
+
+    for (block_index, src_block) in test_struct.blocks.iter().enumerate() {
+        let dst_block = &other_test_struct.blocks[block_index];
+        assert!(src_block.num_elements == dst_block.num_elements);
+        assert!(src_block.condition_item == dst_block.condition_item);
+        assert!(src_block.items == dst_block.items);
+    }
+}
+
+pub fn test_index_operator() {}


### PR DESCRIPTION
This PR implement support for passing parameters from `zserio` object to another. It also adds support for the index operator, which is related to parameter passing.

During encoding/decoding, parameters are processed as follows:
- during deserialization, the parameters are passed as specified in the `zserio` code.
- during serialization, the parameters are expected to be set correctly. In case the parameters were not passed correctly, or do not match, the serialization logic will raise an assertion. This design choice was made, because during serialization, the objects should not be mutable, so the expectation is that parameter passing has already happened before.
- This PR also adds array length assertions to double check that the array lengths given in the `zserio` code has been respected in the rust code. If the array length does not match, an assertion will be triggered.