### PR TITLE
Add a Test Case to test Ambiguous Types

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,6 @@
-ignore = ["src/internal/parser/gen"]
+ignore = [
+    "src/internal/parser/gen",
+    "tests/round-trip-tests"
+]
+
 unstable_features = true

--- a/src/internal/ast/zchoice.rs
+++ b/src/internal/ast/zchoice.rs
@@ -104,6 +104,7 @@ impl ZChoice {
                             .symbol
                             .as_ref()
                             .unwrap()
+                            .symbol
                         {
                             Symbol::Parameter(p) => {
                                 let mut operand2 = Box::from(condition_expression.clone());

--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -4,12 +4,13 @@ use crate::internal::ast::field::Field;
 use crate::internal::ast::type_reference::TypeReference;
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::ModelScope;
-use crate::internal::generator::types::convert_field_name;
+use crate::internal::generator::types::{convert_field_name, TypeGenerator};
 
 use crate::internal::generator::{array::array_type_name, array::initialize_array_trait};
 
 pub fn bitsize_type_reference(
     _scope: &ModelScope,
+    type_generator: &TypeGenerator,
     function: &mut Function,
     field_name: &str,
     is_marshaler: bool,
@@ -54,7 +55,7 @@ pub fn bitsize_type_reference(
             function.line(format!(
                 "end_position += context_node.children[{}].context.bitsize_of(&{}, end_position, &{});",
                 node_idx,
-                initialize_array_trait(type_reference),
+                initialize_array_trait(type_generator, type_reference),
                 field_name,
             ));
         } else {
@@ -109,6 +110,7 @@ pub fn bitsize_type_reference(
 
 pub fn bitsize_field(
     scope: &ModelScope,
+    type_generator: &TypeGenerator,
     function: &mut Function,
     field: &Field,
     context_node_index: Option<u8>,
@@ -132,6 +134,7 @@ pub fn bitsize_field(
     } else {
         bitsize_type_reference(
             scope,
+            type_generator,
             function,
             &field_name,
             native_type.is_marshaler,

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -3,13 +3,13 @@ use crate::internal::ast::expression::{
 };
 use crate::internal::compiler::symbol_scope::Symbol;
 use crate::internal::generator::types::{
-    convert_field_name, convert_to_enum_field_name, custom_type_to_rust_type, to_rust_type_name,
+    convert_field_name, convert_to_enum_field_name, custom_type_to_rust_type, TypeGenerator,
 };
 use crate::internal::parser::gen::zserioparser::{
     AND, BANG, BINARY_LITERAL, BOOL_LITERAL, DECIMAL_LITERAL, DIVIDE, DOT, DOUBLE_LITERAL, EQ,
     FLOAT_LITERAL, GE, GT, HEXADECIMAL_LITERAL, ID, INDEX, LBRACKET, LE, LENGTHOF, LOGICAL_AND,
     LOGICAL_OR, LPAREN, LSHIFT, LT, MINUS, MODULO, MULTIPLY, NE, NUMBITS, OCTAL_LITERAL, OR, PLUS,
-    QUESTIONMARK, RPAREN, RSHIFT, TILDE, VALUEOF, XOR,
+    QUESTIONMARK, RPAREN, RSHIFT, STRING_LITERAL, TILDE, VALUEOF, XOR,
 };
 
 pub struct ExpressionGenerationResult {
@@ -18,32 +18,36 @@ pub struct ExpressionGenerationResult {
     pub lvalue_name: String,
 }
 
-pub fn generate_expression(expression: &Expression) -> String {
+pub fn generate_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     assert!(expression.evaluation_state == EvaluationState::Completed);
     match expression.expression_type {
         LPAREN => format!(
             "({})",
-            generate_expression(expression.operand1.as_ref().unwrap())
+            generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
         ),
         RPAREN => format!(
             "{}()",
-            generate_expression(expression.operand1.as_ref().unwrap())
+            generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
         ),
-        LBRACKET => generate_bracketed_expression(expression),
-        DOT => generate_dot_expression(expression),
-        VALUEOF => generate_valueof_expression(expression),
-        LENGTHOF => generate_lengthof_expression(expression),
-        NUMBITS => generate_numbits_expression(expression),
-        EQ | GE | GT | LE | LT | NE => generate_comparison_expression(expression),
-        PLUS | MINUS | MULTIPLY | DIVIDE | MODULO => generate_arithmetic_expression(expression),
-        QUESTIONMARK => generate_ternary_expression(expression),
-        BANG => generate_logical_negation(expression),
-        TILDE => generate_bitwise_negation(expression),
-        AND | OR | XOR | LSHIFT | RSHIFT => generate_bitwise_expression(expression),
-        LOGICAL_AND | LOGICAL_OR => generate_logical_expression(expression),
-        ID => generate_identifier_expression(expression),
+        LBRACKET => generate_bracketed_expression(expression, type_generator),
+        DOT => generate_dot_expression(expression, type_generator),
+        VALUEOF => generate_valueof_expression(expression, type_generator),
+        LENGTHOF => generate_lengthof_expression(expression, type_generator),
+        NUMBITS => generate_numbits_expression(expression, type_generator),
+        EQ | GE | GT | LE | LT | NE => generate_comparison_expression(expression, type_generator),
+        PLUS | MINUS | MULTIPLY | DIVIDE | MODULO => {
+            generate_arithmetic_expression(expression, type_generator)
+        }
+        QUESTIONMARK => generate_ternary_expression(expression, type_generator),
+        BANG => generate_logical_negation(expression, type_generator),
+        TILDE => generate_bitwise_negation(expression, type_generator),
+        AND | OR | XOR | LSHIFT | RSHIFT => generate_bitwise_expression(expression, type_generator),
+        LOGICAL_AND | LOGICAL_OR => generate_logical_expression(expression, type_generator),
+        ID => generate_identifier_expression(expression, type_generator),
         BOOL_LITERAL | OCTAL_LITERAL | HEXADECIMAL_LITERAL | BINARY_LITERAL | DECIMAL_LITERAL
-        | FLOAT_LITERAL | DOUBLE_LITERAL => generate_literal_expression(expression),
+        | FLOAT_LITERAL | DOUBLE_LITERAL | STRING_LITERAL => {
+            generate_literal_expression(expression)
+        }
         INDEX => generate_index_operator(),
         /*
         0xFFFFF => (), // Ignore
@@ -52,7 +56,10 @@ pub fn generate_expression(expression: &Expression) -> String {
     }
 }
 
-fn generate_unary_arithmetic_expression(expression: &Expression) -> String {
+fn generate_unary_arithmetic_expression(
+    expression: &Expression,
+    type_generator: &TypeGenerator,
+) -> String {
     format!(
         "{}{}",
         match expression.expression_type {
@@ -60,19 +67,22 @@ fn generate_unary_arithmetic_expression(expression: &Expression) -> String {
             MINUS => "-",
             _ => panic!("unexpected unary arithmetic expression operator"),
         },
-        generate_expression(expression.operand1.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_arithmetic_expression(expression: &Expression) -> String {
+fn generate_arithmetic_expression(
+    expression: &Expression,
+    type_generator: &TypeGenerator,
+) -> String {
     if expression.operand2.is_none() {
         // an arithmetic expression may be +5 or -5, i.e. a sign
         // of a float or integer expression.
-        return generate_unary_arithmetic_expression(expression);
+        return generate_unary_arithmetic_expression(expression, type_generator);
     }
     format!(
         "{} {} {}",
-        generate_expression(expression.operand1.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
         match expression.expression_type {
             PLUS => "+",
             MINUS => "-",
@@ -81,28 +91,33 @@ fn generate_arithmetic_expression(expression: &Expression) -> String {
             MODULO => "%",
             _ => panic!("unexpected arithmetic expression operator"),
         },
-        generate_expression(expression.operand2.as_ref().unwrap()),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_bracketed_expression(expression: &Expression) -> String {
+fn generate_bracketed_expression(
+    expression: &Expression,
+    type_generator: &TypeGenerator,
+) -> String {
     format!(
         "{}[{}]",
-        generate_expression(expression.operand1.as_ref().unwrap()),
-        generate_expression(expression.operand2.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_dot_expression(expression: &Expression) -> String {
+fn generate_dot_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     let op1 = expression.operand1.as_ref().unwrap();
 
     return match &op1.result_type {
         ExpressionType::Enum(z_enum) => {
-            format!(
+            let enum_expression = format!(
                 "{}::{}",
                 custom_type_to_rust_type(&z_enum.borrow().name),
                 convert_to_enum_field_name(&expression.operand2.as_ref().unwrap().text)
-            )
+            );
+            type_generator
+                .get_full_module_path(&op1.symbol.as_ref().unwrap().package, &enum_expression)
         }
         ExpressionType::BitMask(z_bitmask) => {
             format!(
@@ -112,10 +127,11 @@ fn generate_dot_expression(expression: &Expression) -> String {
             )
         }
         ExpressionType::Compound => {
-            match op1
+            match &op1
                 .symbol
                 .as_ref()
                 .expect("failed to retrieve the symbol of compound expression")
+                .symbol
             {
                 Symbol::Field(z_field) => {
                     let op2 = expression
@@ -164,44 +180,55 @@ fn generate_dot_expression(expression: &Expression) -> String {
     };
 }
 
-fn generate_valueof_expression(expression: &Expression) -> String {
+fn generate_valueof_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "ztype::valueof({})",
-        generate_expression(expression.operand1.as_ref().unwrap())
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
     )
 }
 
-fn generate_lengthof_expression(expression: &Expression) -> String {
+fn generate_lengthof_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "{}.len()",
-        generate_expression(expression.operand1.as_ref().unwrap())
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
     )
 }
 
-fn generate_numbits_expression(expression: &Expression) -> String {
+fn generate_numbits_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "{} as u32",
-        generate_expression(expression.operand1.as_ref().unwrap())
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
     )
 }
 
-fn generate_identifier_expression(expression: &Expression) -> String {
-    match expression.symbol.as_ref().unwrap() {
-        Symbol::Struct(s) => to_rust_type_name(&s.borrow().name),
-        Symbol::Choice(c) => to_rust_type_name(&c.borrow().name),
-        Symbol::Union(u) => to_rust_type_name(&u.borrow().name),
-        Symbol::Enum(e) => to_rust_type_name(&e.borrow().name),
-        Symbol::Bitmask(bitmask) => to_rust_type_name(&bitmask.borrow().name),
-        Symbol::Field(f) => format!("self.{}", convert_field_name(&f.borrow().name)),
-        Symbol::Parameter(p) => format!("self.{}", convert_field_name(&p.borrow().name)),
+fn generate_identifier_expression(
+    expression: &Expression,
+    type_generator: &TypeGenerator,
+) -> String {
+    let symbol_ref = expression.symbol.as_ref().unwrap();
+
+    // check for early returns, where no full type addressing is needed.
+    match &symbol_ref.symbol {
+        Symbol::Field(f) => return format!("self.{}", convert_field_name(&f.borrow().name)),
+        Symbol::Parameter(p) => return format!("self.{}", convert_field_name(&p.borrow().name)),
         Symbol::Function(z_function) => {
-            format!("self.{}", convert_field_name(&z_function.borrow().name))
+            return format!("self.{}", convert_field_name(&z_function.borrow().name))
         }
-        _ => panic!("unsupported identifier type {:?}", expression.symbol),
+        _ => (),
     }
+
+    let rust_symbol_name = match &symbol_ref.symbol {
+        Symbol::Struct(s) => custom_type_to_rust_type(&s.borrow().name),
+        Symbol::Choice(c) => custom_type_to_rust_type(&c.borrow().name),
+        Symbol::Union(u) => custom_type_to_rust_type(&u.borrow().name),
+        Symbol::Enum(e) => custom_type_to_rust_type(&e.borrow().name),
+        Symbol::Bitmask(bitmask) => custom_type_to_rust_type(&bitmask.borrow().name),
+        _ => panic!("unsupported identifier type {:?}", expression.symbol),
+    };
+    type_generator.get_full_module_path(&symbol_ref.package, &rust_symbol_name)
 }
 
-fn generate_ternary_expression(expression: &Expression) -> String {
+fn generate_ternary_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "
 if {} {{
@@ -209,30 +236,30 @@ if {} {{
 }} else {{
     {}
 }}",
-        generate_expression(expression.operand1.as_ref().unwrap()),
-        generate_expression(expression.operand2.as_ref().unwrap()),
-        generate_expression(expression.operand3.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
+        generate_expression(expression.operand3.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_logical_negation(expression: &Expression) -> String {
+fn generate_logical_negation(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "!{}",
-        generate_expression(expression.operand1.as_ref().unwrap())
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
     )
 }
 
-fn generate_bitwise_negation(expression: &Expression) -> String {
+fn generate_bitwise_negation(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "~{}",
-        generate_expression(expression.operand1.as_ref().unwrap())
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator)
     )
 }
 
-fn generate_bitwise_expression(expression: &Expression) -> String {
+fn generate_bitwise_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "{} {} {}",
-        generate_expression(expression.operand1.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
         match expression.expression_type {
             AND => "&",
             OR => "|",
@@ -241,27 +268,30 @@ fn generate_bitwise_expression(expression: &Expression) -> String {
             RSHIFT => ">>",
             _ => panic!("unexpected bitwise expression operator"),
         },
-        generate_expression(expression.operand2.as_ref().unwrap()),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_logical_expression(expression: &Expression) -> String {
+fn generate_logical_expression(expression: &Expression, type_generator: &TypeGenerator) -> String {
     format!(
         "{} {} {}",
-        generate_expression(expression.operand1.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
         match expression.expression_type {
             LOGICAL_AND => "&&",
             LOGICAL_OR => "||",
             _ => panic!("unexpected logical expression operator"),
         },
-        generate_expression(expression.operand2.as_ref().unwrap()),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
     )
 }
 
-fn generate_comparison_expression(expression: &Expression) -> String {
+fn generate_comparison_expression(
+    expression: &Expression,
+    type_generator: &TypeGenerator,
+) -> String {
     format!(
         "{} {} {}",
-        generate_expression(expression.operand1.as_ref().unwrap()),
+        generate_expression(expression.operand1.as_ref().unwrap(), type_generator),
         match expression.expression_type {
             EQ => "==",
             LE => "<=",
@@ -271,7 +301,7 @@ fn generate_comparison_expression(expression: &Expression) -> String {
             NE => "!=",
             _ => panic!("unexpected comparison expression operator"),
         },
-        generate_expression(expression.operand2.as_ref().unwrap()),
+        generate_expression(expression.operand2.as_ref().unwrap(), type_generator),
     )
 }
 
@@ -279,10 +309,12 @@ fn generate_literal_expression(expression: &Expression) -> String {
     let mut float_value = 0.0;
     let mut int_value = 0;
     let mut bool_value = false;
-    match expression.result_type {
-        ExpressionType::Integer(v) => int_value = v,
-        ExpressionType::Bool(b) => bool_value = b,
-        ExpressionType::Float(f) => float_value = f,
+    let mut string_value = String::from("");
+    match &expression.result_type {
+        ExpressionType::Integer(v) => int_value = *v,
+        ExpressionType::Bool(b) => bool_value = *b,
+        ExpressionType::Float(f) => float_value = *f,
+        ExpressionType::String(s) => string_value = s.clone(),
         _ => panic!(),
     };
 
@@ -298,6 +330,7 @@ fn generate_literal_expression(expression: &Expression) -> String {
                 String::from("false")
             }
         }
+        STRING_LITERAL => format!("\"{}\".into()", &string_value),
 
         _ => panic!("unexpected comparison expression operator"),
     }

--- a/src/internal/generator/function.rs
+++ b/src/internal/generator/function.rs
@@ -1,22 +1,30 @@
 use crate::internal::ast::zfunction::ZFunction;
 use crate::internal::generator::expression::generate_expression;
-use crate::internal::generator::types::{convert_to_function_name, ztype_to_rust_type};
+use crate::internal::generator::types::{convert_to_function_name, TypeGenerator};
 use codegen::Impl;
 
-pub fn generate_function(codegen_scope: &mut Impl, zserio_function: &ZFunction) {
+pub fn generate_function(
+    codegen_scope: &mut Impl,
+    type_generator: &TypeGenerator,
+    zserio_function: &ZFunction,
+) {
     // Generates a rust function for a zserio function.
 
     // Generate the function (empty for now), using the return type, name, and self-reference.
     let fn_gen_scope =
         codegen_scope.new_fn(convert_to_function_name(&zserio_function.name).as_str());
-    fn_gen_scope.ret(ztype_to_rust_type(&zserio_function.return_type).as_str());
+    fn_gen_scope.ret(
+        type_generator
+            .ztype_to_rust_type(&zserio_function.return_type)
+            .as_str(),
+    );
     fn_gen_scope.arg_ref_self();
     fn_gen_scope.vis("pub");
 
     // Generate the function content.
     fn_gen_scope.line(format!(
         "({}) as {}",
-        generate_expression(&zserio_function.result.as_ref().borrow()),
-        ztype_to_rust_type(&zserio_function.return_type),
+        generate_expression(&zserio_function.result.as_ref().borrow(), type_generator),
+        type_generator.ztype_to_rust_type(&zserio_function.return_type),
     ));
 }

--- a/src/internal/generator/model.rs
+++ b/src/internal/generator/model.rs
@@ -2,7 +2,7 @@ use crate::internal::generator::package::generate_package;
 use crate::internal::model::Model;
 use std::path::Path;
 
-pub fn generate_model(model: &mut Model, target_directory: &Path, root_package: &String) {
+pub fn generate_model(model: &mut Model, target_directory: &Path, root_package: &str) {
     let scope = &mut model.scope;
     for package in model.packages.values() {
         generate_package(scope, package, target_directory, root_package);

--- a/src/internal/generator/new.rs
+++ b/src/internal/generator/new.rs
@@ -5,11 +5,17 @@ use crate::internal::ast::{field::Array, field::Field, parameter::Parameter};
 use crate::internal::ast::type_reference::TypeReference;
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::ModelScope;
-use crate::internal::generator::types::{convert_field_name, ztype_to_rust_type};
+use crate::internal::generator::types::{convert_field_name, TypeGenerator};
 
-pub fn new_field(scope: &ModelScope, function: &mut Function, field: &Field) {
+pub fn new_field(
+    scope: &ModelScope,
+    type_generator: &TypeGenerator,
+    function: &mut Function,
+    field: &Field,
+) {
     new_type(
         scope,
+        type_generator,
         function,
         &field.name,
         &field.field_type,
@@ -18,9 +24,15 @@ pub fn new_field(scope: &ModelScope, function: &mut Function, field: &Field) {
     );
 }
 
-pub fn new_param(scope: &ModelScope, function: &mut Function, param: &Parameter) {
+pub fn new_param(
+    scope: &ModelScope,
+    type_generator: &TypeGenerator,
+    function: &mut Function,
+    param: &Parameter,
+) {
     new_type(
         scope,
+        type_generator,
         function,
         &param.name,
         &param.zserio_type,
@@ -63,6 +75,7 @@ pub fn get_default_initializer(
 }
 pub fn new_type(
     scope: &ModelScope,
+    type_generator: &TypeGenerator,
     function: &mut Function,
     name: &String,
     type_reference: &TypeReference,
@@ -72,7 +85,7 @@ pub fn new_type(
     let native_type = get_fundamental_type(type_reference, scope);
     let fund_type = native_type.fundamental_type;
     let field_name = convert_field_name(name);
-    let rust_type = ztype_to_rust_type(type_reference);
+    let rust_type = type_generator.ztype_to_rust_type(type_reference);
 
     function.line(format!(
         "{}: {},",

--- a/src/internal/generator/preamble.rs
+++ b/src/internal/generator/preamble.rs
@@ -1,4 +1,3 @@
-use crate::internal::ast::package::ZPackage;
 use codegen::Scope;
 
 pub fn add_standard_imports(scope: &mut Scope) {
@@ -9,35 +8,4 @@ pub fn add_standard_imports(scope: &mut Scope) {
         "rust_zserio::ztype::array_traits::packing_context_node",
         "PackingContextNode",
     );
-}
-
-pub fn get_default_scope(package: &ZPackage, root_package: &String) -> Scope {
-    let mut scope = Scope::new();
-    // TODO Add a header comment
-
-    let mut root_import = String::from("crate");
-    if !root_package.is_empty() {
-        root_import = root_import + "::" + root_package.as_str();
-    }
-
-    for import in &package.imports {
-        let mut import_str = root_import.clone();
-        for import_part in &import.package_dir {
-            import_str = import_str + "::" + import_part.as_str();
-        }
-
-        let symbol_import = match &import.symbol_name {
-            None => "*".into(),
-            Some(symbol_name) => symbol_name.clone(),
-        };
-        scope.import(import_str.as_str(), symbol_import.as_str());
-    }
-
-    // Add the import to the current (own) module
-    scope.import(
-        (root_import + "::" + package.name.replace('.', "::").as_str()).as_str(),
-        "*",
-    );
-
-    scope
 }

--- a/src/internal/generator/subtype.rs
+++ b/src/internal/generator/subtype.rs
@@ -1,14 +1,13 @@
 use crate::internal::ast::zsubtype::Subtype;
 use crate::internal::generator::file_generator::write_to_file;
 use crate::internal::generator::preamble::add_standard_imports;
-use crate::internal::generator::types::{
-    to_rust_module_name, to_rust_type_name, ztype_to_rust_type,
-};
+use crate::internal::generator::types::{to_rust_module_name, to_rust_type_name, TypeGenerator};
 use codegen::Scope;
 use std::path::Path;
 
 pub fn generate_subtype(
     codegen_scope: &mut Scope,
+    type_generator: &TypeGenerator,
     subtype: &Subtype,
     path: &Path,
     package_name: &str,
@@ -18,7 +17,7 @@ pub fn generate_subtype(
     let rust_module_name = to_rust_module_name(&subtype.name);
     let type_alias_scope = codegen_scope.new_type_alias(
         to_rust_type_name(&subtype.name),
-        &ztype_to_rust_type(&subtype.zserio_type),
+        &type_generator.ztype_to_rust_type(&subtype.zserio_type),
     );
     type_alias_scope.vis("pub");
 

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -6,7 +6,7 @@ use crate::internal::generator::{
     bitsize::bitsize_field, decode::decode_field, encode::encode_field,
     file_generator::write_to_file, function::generate_function, new::new_field, new::new_param,
     preamble::add_standard_imports, types::convert_field_name, types::to_rust_module_name,
-    types::to_rust_type_name, types::ztype_to_rust_type,
+    types::to_rust_type_name, types::TypeGenerator,
 };
 use codegen::Scope;
 use codegen::Struct;
@@ -15,8 +15,12 @@ use std::rc::Rc;
 
 use std::path::Path;
 
-pub fn generate_struct_member_for_field(gen_struct: &mut Struct, field: &Field) {
-    let mut field_type = ztype_to_rust_type(field.field_type.as_ref());
+pub fn generate_struct_member_for_field(
+    type_generator: &TypeGenerator,
+    gen_struct: &mut Struct,
+    field: &Field,
+) {
+    let mut field_type = type_generator.ztype_to_rust_type(field.field_type.as_ref());
 
     if field.array.is_some() {
         field_type = format!("Vec<{}>", field_type.as_str());
@@ -30,6 +34,7 @@ pub fn generate_struct_member_for_field(gen_struct: &mut Struct, field: &Field) 
 
 pub fn generate_struct(
     symbol_scope: &ModelScope,
+    type_generator: &TypeGenerator,
     codegen_scope: &mut Scope,
     zstruct: &ZStruct,
     path: &Path,
@@ -49,7 +54,8 @@ pub fn generate_struct(
 
     // if the field is parameterized, add the parameters as member variables
     for param in &zstruct.type_parameters {
-        let param_type = ztype_to_rust_type(param.as_ref().borrow().zserio_type.as_ref());
+        let param_type =
+            type_generator.ztype_to_rust_type(param.as_ref().borrow().zserio_type.as_ref());
         // Possible improvement: currently the parameters are copied instead of taken the reference.
         // It would be great to change that to references to avoid unnecessary copying, but this is
         // painful in rust due to the lifetime checks.
@@ -63,7 +69,7 @@ pub fn generate_struct(
 
     // Add the data fields to the struct
     for field in &zstruct.fields {
-        generate_struct_member_for_field(gen_struct, &field.borrow());
+        generate_struct_member_for_field(type_generator, gen_struct, &field.borrow());
     }
 
     // generate the functions to serialize/deserialize
@@ -76,23 +82,28 @@ pub fn generate_struct(
     new_fn.line(format!("{} {{", &rust_type_name));
 
     for param in &zstruct.type_parameters {
-        new_param(symbol_scope, new_fn, &param.as_ref().borrow());
+        new_param(
+            symbol_scope,
+            type_generator,
+            new_fn,
+            &param.as_ref().borrow(),
+        );
     }
 
     for field in &zstruct.fields {
-        new_field(symbol_scope, new_fn, &field.borrow());
+        new_field(symbol_scope, type_generator, new_fn, &field.borrow());
     }
     new_fn.line("}");
 
     // Generate the functions to read, write and bitcount the data to/from zserio format.
-    generate_zserio_read(symbol_scope, struct_impl, &zstruct.fields);
-    generate_zserio_write(symbol_scope, struct_impl, &zstruct.fields);
-    generate_zserio_bitsize(symbol_scope, struct_impl, &zstruct.fields);
+    generate_zserio_read(symbol_scope, type_generator, struct_impl, &zstruct.fields);
+    generate_zserio_write(symbol_scope, type_generator, struct_impl, &zstruct.fields);
+    generate_zserio_bitsize(symbol_scope, type_generator, struct_impl, &zstruct.fields);
 
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);
     for zserio_function in &zstruct.functions {
-        generate_function(pub_impl, &zserio_function.as_ref().borrow());
+        generate_function(pub_impl, type_generator, &zserio_function.as_ref().borrow());
     }
 
     write_to_file(
@@ -106,25 +117,27 @@ pub fn generate_struct(
 
 fn generate_zserio_read(
     scope: &ModelScope,
+    type_generator: &TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<Rc<RefCell<Field>>>,
 ) {
     let zserio_read_fn = struct_impl.new_fn("zserio_read");
     zserio_read_fn.arg_mut_self();
     zserio_read_fn.arg("reader", "&mut BitReader");
-    instantiate_zserio_arrays(scope, zserio_read_fn, fields, false);
+    instantiate_zserio_arrays(scope, type_generator, zserio_read_fn, fields, false);
     for field in fields {
-        decode_field(scope, zserio_read_fn, &field.borrow(), None);
+        decode_field(scope, type_generator, zserio_read_fn, &field.borrow(), None);
     }
 
     let zserio_read_packed_fn = struct_impl.new_fn("zserio_read_packed");
     zserio_read_packed_fn.arg_mut_self();
     zserio_read_packed_fn.arg("context_node", "&mut PackingContextNode");
     zserio_read_packed_fn.arg("reader", "&mut BitReader");
-    instantiate_zserio_arrays(scope, zserio_read_packed_fn, fields, true);
+    instantiate_zserio_arrays(scope, type_generator, zserio_read_packed_fn, fields, true);
     for field in fields {
         decode_field(
             scope,
+            type_generator,
             zserio_read_packed_fn,
             &field.borrow(),
             Option::from(0),
@@ -134,6 +147,7 @@ fn generate_zserio_read(
 
 fn generate_zserio_write(
     scope: &ModelScope,
+    type_generator: &TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<Rc<RefCell<Field>>>,
 ) {
@@ -141,20 +155,21 @@ fn generate_zserio_write(
     zserio_write_fn.arg_ref_self();
     zserio_write_fn.arg("writer", "&mut BitWriter");
 
-    instantiate_zserio_arrays(scope, zserio_write_fn, fields, false);
+    instantiate_zserio_arrays(scope, type_generator, zserio_write_fn, fields, false);
     for field_rc in fields {
         let field = field_rc.borrow();
-        encode_field(scope, zserio_write_fn, &field, None);
+        encode_field(scope, type_generator, zserio_write_fn, &field, None);
     }
 
     let zserio_write_packed_fn = struct_impl.new_fn("zserio_write_packed");
     zserio_write_packed_fn.arg_ref_self();
     zserio_write_packed_fn.arg("context_node", "&mut PackingContextNode");
     zserio_write_packed_fn.arg("writer", "&mut BitWriter");
-    instantiate_zserio_arrays(scope, zserio_write_packed_fn, fields, true);
+    instantiate_zserio_arrays(scope, type_generator, zserio_write_packed_fn, fields, true);
     for field in fields {
         encode_field(
             scope,
+            type_generator,
             zserio_write_packed_fn,
             &field.borrow(),
             Option::from(0),
@@ -164,6 +179,7 @@ fn generate_zserio_write(
 
 fn generate_zserio_bitsize(
     scope: &ModelScope,
+    type_generator: &TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<Rc<RefCell<Field>>>,
 ) {
@@ -171,10 +187,10 @@ fn generate_zserio_bitsize(
     bitsize_fn.ret("u64");
     bitsize_fn.arg_ref_self();
     bitsize_fn.arg("bit_position", "u64");
-    instantiate_zserio_arrays(scope, bitsize_fn, fields, false);
+    instantiate_zserio_arrays(scope, type_generator, bitsize_fn, fields, false);
     bitsize_fn.line("let mut end_position = bit_position;");
     for field in fields {
-        bitsize_field(scope, bitsize_fn, &field.borrow(), None);
+        bitsize_field(scope, type_generator, bitsize_fn, &field.borrow(), None);
     }
     bitsize_fn.line("end_position - bit_position");
 
@@ -183,10 +199,16 @@ fn generate_zserio_bitsize(
     bitsize_packed_fn.arg_ref_self();
     bitsize_packed_fn.arg("context_node", "&mut PackingContextNode");
     bitsize_packed_fn.arg("bit_position", "u64");
-    instantiate_zserio_arrays(scope, bitsize_packed_fn, fields, true);
+    instantiate_zserio_arrays(scope, type_generator, bitsize_packed_fn, fields, true);
     bitsize_packed_fn.line("let mut end_position = bit_position;");
     for field in fields {
-        bitsize_field(scope, bitsize_packed_fn, &field.borrow(), Option::from(0));
+        bitsize_field(
+            scope,
+            type_generator,
+            bitsize_packed_fn,
+            &field.borrow(),
+            Option::from(0),
+        );
     }
     bitsize_packed_fn.line("end_position - bit_position");
 }

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -9,3 +9,4 @@ import reference_modules.type_lookup_test.ztype.*;
 import reference_modules.type_lookup_test.other_ztype.*;
 import reference_modules.parameter_passing.index_operator.*;
 import reference_modules.parameter_passing.parameter_passing.*;
+import reference_modules.ambiguous_types.ambiguous_types.*;

--- a/tests/reference_modules/ambiguous_types/main.zs
+++ b/tests/reference_modules/ambiguous_types/main.zs
@@ -1,0 +1,18 @@
+package reference_modules.ambiguous_types.main;
+
+import reference_modules.ambiguous_types.other.*;
+
+// See zserio language overview http://zserio.org/doc/ZserioLanguageOverview.html:
+// Import declarations only have any effect when there is a reference to 
+// a type or symbol not defined in the current package. If package map defines 
+// its own Coordinate type, any reference to that within package map will be 
+// resolved to the local type map.Coordinate, even when one or more of the 
+// imported packages also define a type named Coordinate.
+//
+subtype int32 CustomType;
+
+struct AmbiguousTypesStruct {
+    // should resolve to reference_modules.ambiguous_types.main.CustomType,
+    // not reference_modules.ambiguous_types.other.CustomType.
+    CustomType value;
+};

--- a/tests/reference_modules/ambiguous_types/other.zs
+++ b/tests/reference_modules/ambiguous_types/other.zs
@@ -1,0 +1,9 @@
+package reference_modules.ambiguous_types.other;
+
+// This type "clones" the type in main.zs.
+// Since this file is imported from main.zs,
+// the type is in the evaluation scope, but the
+// compiler should pick the definition in main.zs,
+// because local definitions are more relevant than
+// imported ones.
+subtype bool CustomType;

--- a/tests/round-trip-tests/build.rs
+++ b/tests/round-trip-tests/build.rs
@@ -8,5 +8,5 @@ fn main() {
     // Use rust-zserio to generate the new code
     let mut model = Model::from_filesystem(Path::new("../reference_modules"));
     model.evaluate();
-    generate_model(&mut model, Path::new("src"), &String::new());
+    generate_model(&mut model, Path::new("src"), "");
 }

--- a/tests/round-trip-tests/src/ambiguous_types_test.rs
+++ b/tests/round-trip-tests/src/ambiguous_types_test.rs
@@ -1,0 +1,9 @@
+use crate::reference_modules::ambiguous_types::main::ambiguous_types_struct::AmbiguousTypesStruct;
+use rust_zserio::ztype::ZserioPackableOject;
+
+pub fn test_ambiguous_types() {
+    // Create a test structure, and assign a new instance.
+    // If this line compiles, the test passes.
+    let mut test_struct = AmbiguousTypesStruct::new();
+    test_struct.value = 17;
+}

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -13,7 +13,12 @@ pub mod reference_modules {
         pub mod index_operator;
         pub mod parameter_passing;
     }
+    pub mod ambiguous_types {
+        pub mod main;
+        pub mod other;
+    }
 }
+pub mod ambiguous_types_test;
 pub mod parameter_passing_test;
 
 use crate::reference_modules::core::types::{
@@ -29,7 +34,9 @@ use reference_modules::core::instantiations::instantiated_template_struct;
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableOject;
 
+use crate::ambiguous_types_test::test_ambiguous_types;
 use crate::parameter_passing_test::{test_index_operator, test_parameter_passing};
+
 fn main() {
     test_structure();
     test_functions();
@@ -41,6 +48,7 @@ fn main() {
     test_union_type();
     test_parameter_passing();
     test_index_operator();
+    test_ambiguous_types();
 }
 
 fn test_structure() {


### PR DESCRIPTION
- This test case will crash the current implementation: rust will complain that the types are ambiguous.
- This means that the code generation needs to change: instead of using imports, each type must reference the absolute type path.