### PR TITLE
Implement Type Casts during Expression Generation

### DIFF
--- a/src/internal/ast.rs
+++ b/src/internal/ast.rs
@@ -1,3 +1,4 @@
+pub mod evaluate_mixing_native_types;
 pub mod expression;
 pub mod field;
 pub mod package;

--- a/src/internal/ast/evaluate_mixing_native_types.rs
+++ b/src/internal/ast/evaluate_mixing_native_types.rs
@@ -1,0 +1,145 @@
+use crate::internal::ast::type_reference::TypeReference;
+
+fn compare_native_types(type1: &TypeReference, type2: &TypeReference) -> bool {
+    type1.name == type2.name && type1.bits == type2.bits
+}
+
+pub fn evaluate_mixing_float_types(
+    type1: &Option<TypeReference>,
+    type2: &Option<TypeReference>,
+) -> Option<TypeReference> {
+    match (type1, type2) {
+        (Some(t1), Some(t2)) => {
+            // If both types are set, check if they are the same type.
+            if compare_native_types(t1, t2) {
+                return type1.clone();
+            }
+            // Choose the float type with the highest rank.
+            for float_type in ["float64", "float32", "float16"] {
+                if t1.name == float_type || t2.name == float_type {
+                    return Some(TypeReference::new_native_type(float_type));
+                }
+            }
+            panic!("unknown float types");
+        }
+        (Some(_), None) => type1.clone(),
+        (None, Some(_)) => type2.clone(),
+        (None, None) => None,
+    }
+}
+
+fn get_integer_rank(integer_type: &TypeReference) -> u8 {
+    // if the bit length is dynamic, always assume 64bits
+    if integer_type.length_expression.is_some() {
+        return 64;
+    }
+    if integer_type.bits != 0 {
+        return integer_type.bits;
+    }
+    return match integer_type.name.as_str() {
+        "int8" => 8,
+        "int16" => 16,
+        "int32" => 32,
+        "int64" => 64,
+        "varint16" => 15,
+        "varint32" => 29,
+        "varint64" => 57,
+        "varint" => 64,
+        "uint8" => 8,
+        "uint16" => 16,
+        "uint32" => 32,
+        "varuint16" => 15,
+        "varuint32" => 29,
+        "varuint64" => 57,
+        "varsize" => 31,
+        "varuint" => 64,
+        _ => panic!("unexpected integer type {:?}", integer_type),
+    };
+}
+
+pub fn is_signed(int_type_name: &str) -> bool {
+    match int_type_name {
+        "int8" => true,
+        "int16" => true,
+        "int32" => true,
+        "int64" => true,
+        "varint16" => true,
+        "varint32" => true,
+        "varint64" => true,
+        "varint" => true,
+        "uint8" => false,
+        "uint16" => false,
+        "uint32" => false,
+        "varuint16" => false,
+        "varuint32" => false,
+        "varuint64" => false,
+        "varsize" => false,
+        "varuint" => false,
+        _ => panic!("unexpected integer type {:?}", int_type_name),
+    }
+}
+
+pub fn convert_to_unsigned(int_type_name: &str) -> String {
+    match int_type_name {
+        "int8" => "uint8".into(),
+        "int16" => "uint16".into(),
+        "int32" => "uint32".into(),
+        "int64" => "uint64".into(),
+        "varint16" => "varuint16".into(),
+        "varint32" => "varuint32".into(),
+        "varint64" => "varuint64".into(),
+        "varint" => "varuint".into(),
+        _ => panic!("unexpected signed integer type {:?}", int_type_name),
+    }
+}
+
+pub fn evaluate_mixing_integer_types(
+    type1: &Option<TypeReference>,
+    type2: &Option<TypeReference>,
+) -> Option<TypeReference> {
+    // For now, we use the same logic as C++ when mixing integer types:
+    // Mixing signed/unsigned values of the same type (in the sequence of int16, int32, int64),
+    // the unsigned type will win.
+    // Mixing different ranks result in the higher rank being used.
+    match (type1, type2) {
+        (Some(t1), Some(t2)) => {
+            // If both types are set, check if they are the same type.
+            if compare_native_types(t1, t2) {
+                return type1.clone();
+            }
+
+            // Check if there is a mix in signed/unsigned. If yes, the final
+            // type will be a unsigned type (like C++, unsigned wins).
+            let t1_is_signed = is_signed(t1.name.as_str());
+            let t2_is_signed = is_signed(t2.name.as_str());
+            let result_is_signed = t1_is_signed && t2_is_signed;
+
+            // Pick the higher rank.
+            let t1_rank = get_integer_rank(t1);
+            let t2_rank = get_integer_rank(t2);
+
+            if t1_rank > t2_rank {
+                if t1_is_signed == result_is_signed {
+                    // type 1 wins
+                    return Some(t1.clone());
+                }
+                // t1 rank wins, but t2 sign wins
+                let mut result_type = t1.clone();
+                result_type.name = convert_to_unsigned(result_type.name.as_str());
+                return Some(result_type);
+            }
+            if t2_is_signed == result_is_signed {
+                // type 2 wins
+                return Some(t2.clone());
+            }
+            // t2 rank wins, but t1 sign wins
+            let mut result_type = t2.clone();
+            result_type.name = convert_to_unsigned(result_type.name.as_str());
+            Some(result_type)
+        }
+        // Handle cases such as "u16Var + 12"
+        (Some(_), None) => type1.clone(),
+        (None, Some(_)) => type2.clone(),
+        (None, None) => None,
+    }
+}

--- a/src/internal/ast/type_reference.rs
+++ b/src/internal/ast/type_reference.rs
@@ -9,13 +9,36 @@ pub struct TypeReference {
     pub is_builtin: bool,
     pub package: String,
     pub name: String,
-    pub bits: i8,
+    pub bits: u8,
     pub template_arguments: Vec<TypeReference>,
     pub type_arguments: Vec<Rc<RefCell<Expression>>>,
     pub length_expression: Option<Rc<RefCell<Expression>>>,
 }
 
 impl TypeReference {
+    pub fn new_native_type(name: &str) -> TypeReference {
+        TypeReference {
+            is_builtin: true,
+            package: "".into(),
+            name: name.to_owned(),
+            bits: 0,
+            template_arguments: vec![],
+            type_arguments: vec![],
+            length_expression: None,
+        }
+    }
+    pub fn new_native_bit_type(name: &str, num_bits: u8) -> TypeReference {
+        TypeReference {
+            is_builtin: true,
+            package: "".into(),
+            name: name.to_owned(),
+            bits: num_bits,
+            template_arguments: vec![],
+            type_arguments: vec![],
+            length_expression: None,
+        }
+    }
+
     pub fn evaluate(&self, scope: &mut ModelScope) {
         for type_argument in &self.type_arguments {
             type_argument.as_ref().borrow_mut().evaluate(scope);

--- a/src/internal/ast/zchoice.rs
+++ b/src/internal/ast/zchoice.rs
@@ -124,6 +124,7 @@ impl ZChoice {
                                         symbol: None,
                                         fully_resolved: false,
                                         evaluation_state: EvaluationState::NotEvaluated,
+                                        native_type: None,
                                     })),
                                     operand2: Option::from(operand2),
                                     operand3: None,
@@ -132,6 +133,7 @@ impl ZChoice {
                                     symbol: None,
                                     fully_resolved: false,
                                     evaluation_state: EvaluationState::NotEvaluated,
+                                    native_type: None,
                                 });
                             }
                             _ => panic!("selector expression is not a parameter"),

--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -764,6 +764,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -787,6 +788,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -807,6 +809,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -831,6 +834,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         ZserioTreeReturnType::Expression(expression)
     }
@@ -858,12 +862,14 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                 symbol: None,
                 fully_resolved: false,
                 evaluation_state: EvaluationState::NotEvaluated,
+                native_type: None,
             })),
             operand3: None,
             result_type: ExpressionType::Other,
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         }))
     }
 
@@ -883,6 +889,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         }))
     }
 
@@ -929,6 +936,18 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             ),
             _ => panic!("unexpected expression type {:?}, ", literal_text),
         };
+
+        // Determine the exact zserio type for this literal.
+        let native_type = match literal_ctx {
+            _ if literal_ctx.BOOL_LITERAL().is_some() => {
+                Some(TypeReference::new_native_type("bool"))
+            }
+            _ if literal_ctx.STRING_LITERAL().is_some() => {
+                Some(TypeReference::new_native_type("string"))
+            }
+            _ => None,
+        };
+
         let expression_type = literal_ctx.start().token_type;
         ZserioTreeReturnType::Expression(Box::new(Expression {
             expression_type,
@@ -941,6 +960,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             result_type,
             fully_resolved: true,
             evaluation_state: EvaluationState::Completed,
+            native_type,
         }))
     }
 
@@ -963,6 +983,9 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            // We assume that a lengthof expression always returns an varsize type.
+            // This must match with the generated type during expression generation.
+            native_type: Some(TypeReference::new_native_type("varsize")),
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -983,6 +1006,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1003,6 +1027,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: Some(TypeReference::new_native_type("usize")),
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1023,6 +1048,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression().unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1046,6 +1072,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1070,6 +1097,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1094,6 +1122,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1126,6 +1155,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1150,6 +1180,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1177,6 +1208,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1201,6 +1233,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1228,6 +1261,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1255,6 +1289,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: Some(TypeReference::new_native_type("bool")),
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1279,6 +1314,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: Some(TypeReference::new_native_type("bool")),
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1303,6 +1339,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             symbol: None,
             fully_resolved: false,
             evaluation_state: EvaluationState::NotEvaluated,
+            native_type: None,
         });
         match self.visit(&*ctx.expression(0).unwrap()) {
             ZserioTreeReturnType::Expression(e) => expression.operand1 = Option::from(e),
@@ -1373,12 +1410,12 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             // This is a built-in type, e.g. string, uint32, bit:x, ....
             type_reference.is_builtin = true;
             let mut name = ctx.get_text();
-            let mut bits: i8 = 0;
+            let mut bits: u8 = 0;
             if name.contains(':') {
                 let bits_subst: Vec<&str> = name.split(':').collect();
                 bits = bits_subst[1]
-                    .parse::<i8>()
-                    .expect("failed to convert to i8");
+                    .parse::<u8>()
+                    .expect("failed to convert to u8");
                 name = bits_subst[0].into();
             }
             type_reference.name = name;
@@ -1461,6 +1498,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                 symbol: None,
                 fully_resolved: false,
                 evaluation_state: EvaluationState::NotEvaluated,
+                native_type: None,
             }));
         }
         self.visit(&*ctx.expression().unwrap())

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -11,3 +11,4 @@ import reference_modules.parameter_passing.index_operator.*;
 import reference_modules.parameter_passing.parameter_passing.*;
 import reference_modules.ambiguous_types.ambiguous_types.*;
 import reference_modules.template_instantiation.template_instantiation.*;
+import reference_modules.type_casts.type_casts.*;

--- a/tests/reference_modules/type_casts/type_casts.zs
+++ b/tests/reference_modules/type_casts/type_casts.zs
@@ -1,0 +1,17 @@
+package reference_modules.type_casts.type_casts;
+
+struct TypeCastStruct {
+    int32 i32Value;
+    uint32 u32Value;
+    float16 f16Value;
+    varint64 vi64Value;
+    int32 i32Array[3];
+
+
+    function float32 testTypeCasts()
+    {
+        // Test mixing different integer types, and make
+        // sure the generated code handles type casts correctly.
+        return i32Value + u32Value + vi64Value + lengthof(i32Array);   
+    }
+};

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -20,10 +20,14 @@ pub mod reference_modules {
     pub mod template_instantiation {
         pub mod template_instantiation;
     }
+    pub mod type_casts {
+        pub mod type_casts;
+    }
 }
 pub mod ambiguous_types_test;
 pub mod parameter_passing_test;
 pub mod template_instantiation_test;
+pub mod type_casts_test;
 
 use crate::reference_modules::core::types::{
     basic_choice::BasicChoice, color::Color, extern_test_case::ExternTestCase, some_enum::SomeEnum,
@@ -40,6 +44,7 @@ use rust_zserio::ztype::ZserioPackableOject;
 
 use crate::ambiguous_types_test::test_ambiguous_types;
 use crate::parameter_passing_test::{test_index_operator, test_parameter_passing};
+use crate::type_casts_test::test_type_casts;
 
 fn main() {
     test_structure();
@@ -53,6 +58,7 @@ fn main() {
     test_parameter_passing();
     test_index_operator();
     test_ambiguous_types();
+    test_type_casts();
 }
 
 fn test_structure() {

--- a/tests/round-trip-tests/src/type_casts_test.rs
+++ b/tests/round-trip-tests/src/type_casts_test.rs
@@ -1,0 +1,11 @@
+use crate::reference_modules::type_casts::type_casts::type_cast_struct::TypeCastStruct;
+
+use rust_zserio::ztype::ZserioPackableOject;
+
+pub fn test_type_casts() {
+    // The test structure created in this test generates a function that
+    // requires a lot of type casts.
+    // The test passes if the generated structure compiles.
+    let test_struct = TypeCastStruct::new();
+    test_struct.test_type_casts();
+}


### PR DESCRIPTION
Rust has pretty strict type cast requirements, and won't do any implicit casts (unlike C++, for example). Therefore, it is needed that the zserio compiler keeps track of the types used in the `zserio` definition files, and remembers which type was used in which expression.
That information is needed to generate the typecasts, that in other languages would happen implicitly.
The `Expression` type has been enhanced to keep track of a type reference, which matches the `zserio` type of the expression. When expressions are combined with other expressions, the resulting expressions may have a different type.

For example, the expression `u16_var + i32_var` takes an `u16` type, and adds it with an `i32` type. The resulting type will be `u32`, because:
- the higher number of bits win (32 vs 16).
- when mixing signed with unsigned, unsigned wins.

