### PR TITLE
Fix Array Reading/Writing, when the array length is passed as a parameter

### DIFF
--- a/tests/reference_modules/parameterized_array_length/parameterized_array_length.zs
+++ b/tests/reference_modules/parameterized_array_length/parameterized_array_length.zs
@@ -1,0 +1,8 @@
+package reference_modules.parameterized_array_length.parameterized_array_length;
+
+
+struct ParameterizedArrayLength
+{
+    uint16 numElements;
+    uint32 data[numElements];
+};

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -35,6 +35,9 @@ pub mod reference_modules {
     pub mod integer_types {
         pub mod integer_types;
     }
+    pub mod parameterized_array_length {
+        pub mod parameterized_array_length;
+    }
 }
 pub mod ambiguous_types_test;
 pub mod parameter_passing_test;
@@ -44,6 +47,7 @@ pub mod optional_values_test;
 pub mod bitmask_test;
 pub mod constants_test;
 pub mod integer_types_test;
+pub mod parameterized_array_length_test;
 
 use crate::reference_modules::core::types::{
     basic_choice::BasicChoice, color::Color, extern_test_case::ExternTestCase, some_enum::SomeEnum,
@@ -65,6 +69,7 @@ use crate::optional_values_test::{ test_optional_values, test_optional_members, 
 use crate::bitmask_test::test_bitmasks;
 use crate::constants_test::test_constants;
 use crate::integer_types_test::test_integer_types;
+use crate::parameterized_array_length_test::test_parameterized_array_length;
 
 
 fn main() {
@@ -86,6 +91,7 @@ fn main() {
     test_bitmasks();
     test_constants();
     test_integer_types();
+    test_parameterized_array_length();
 }
 
 fn test_structure() {

--- a/tests/round-trip-tests/src/parameterized_array_length_test.rs
+++ b/tests/round-trip-tests/src/parameterized_array_length_test.rs
@@ -1,0 +1,31 @@
+use crate::reference_modules::parameterized_array_length::parameterized_array_length::parameterized_array_length::ParameterizedArrayLength;
+
+use bitreader::BitReader;
+use rust_bitwriter::BitWriter;
+use rust_zserio::ztype::ZserioPackableOject;
+
+pub fn test_parameterized_array_length() {
+    let test_struct = ParameterizedArrayLength {
+        num_elements: 2,
+        data: vec![10, 15], // the array length should be specified by num_elements
+        
+    };
+
+    // The bit length should be 16 (for num_elements) + 2 * 32 (for data).
+    // there should no array length be encoded, as the array length is given
+    // using num_elements.
+    assert!(test_struct.zserio_bitsize(0) == 16 + 2 * 32, "bit length of parameterized array length doesn't match");
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    test_struct.zserio_write(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_test_struct = ParameterizedArrayLength::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct.zserio_read(&mut bitreader);
+
+    // expect them to be identical.
+    assert!(test_struct == other_test_struct);
+}


### PR DESCRIPTION
- In some cases, the array length is not explicitly hard-coded as a number, but using an expression, which makes the value depend on another variable, or struct field. In that case, the array length does not need to be stored redudantly in the byte stream.
- This PR fixes the bug by properly passing the array length expression, and not writing the array length to the byte stream if not needed.
- This PR also adds a test case to cover such scenarios.