### PR TITLE
Fix folder naming when generating the rust code

### DIFF
--- a/src/internal/generator/file_generator.rs
+++ b/src/internal/generator/file_generator.rs
@@ -1,3 +1,4 @@
+use crate::internal::generator::types::to_rust_module_name;
 use rust_format::{Formatter, RustFmt};
 use std::fs;
 use std::io::Write;
@@ -17,7 +18,7 @@ pub fn write_to_file(content: &String, root_path: &Path, zserio_pkg_name: &str, 
 
     let mut file_path = root_path.to_owned();
     for dir in String::from(zserio_pkg_name).split('.') {
-        file_path = file_path.join(dir);
+        file_path = file_path.join(to_rust_module_name(dir));
     }
     fs::create_dir_all(file_path.as_path()).expect("mkdir failed");
     let filename = file_path.join(String::from(file_name) + ".rs");

--- a/src/internal/generator/package.rs
+++ b/src/internal/generator/package.rs
@@ -2,9 +2,9 @@ use crate::internal::ast::package::ZPackage;
 use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::file_generator::write_to_file;
 use crate::internal::generator::{
-    subtype::generate_subtype, types::to_rust_module_name, types::TypeGenerator,
-    zbitmask::generate_bitmask, zchoice::generate_choice, zconst::generate_constant,
-    zenum::generate_enum, zstruct::generate_struct, zunion::generate_union,
+    subtype::generate_subtype, types::TypeGenerator, zbitmask::generate_bitmask,
+    zchoice::generate_choice, zconst::generate_constant, zenum::generate_enum,
+    zstruct::generate_struct, zunion::generate_union,
 };
 use codegen::Scope;
 use std::path::Path;
@@ -15,7 +15,7 @@ pub fn generate_package(
     package_directory: &Path,
     root_package: &str,
 ) {
-    let package_name = to_rust_module_name(&package.name);
+    let package_name = &package.name;
     let mut module_names = Vec::new();
     let type_generator = TypeGenerator {
         root_package_name: root_package.to_owned(),
@@ -35,7 +35,7 @@ pub fn generate_package(
             &mut gen_scope,
             &z_struct,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -53,7 +53,7 @@ pub fn generate_package(
             &mut gen_scope,
             &z_choice,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -71,7 +71,7 @@ pub fn generate_package(
             &mut gen_scope,
             &zunion,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -85,7 +85,7 @@ pub fn generate_package(
             &mut gen_scope,
             &z_enum,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -99,7 +99,7 @@ pub fn generate_package(
             &mut gen_scope,
             &zbitmask,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -116,7 +116,7 @@ pub fn generate_package(
             &type_generator,
             &zsubtype,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -130,7 +130,7 @@ pub fn generate_package(
             &mut codegen_scope,
             &zconst,
             package_directory,
-            &package_name,
+            package_name,
         ));
     }
 
@@ -149,5 +149,5 @@ pub fn generate_package(
         mod_file_content += format!("pub mod {};\n", module_name).as_str();
     }
 
-    write_to_file(&mod_file_content, package_directory, &package_name, "mod");
+    write_to_file(&mod_file_content, package_directory, package_name, "mod");
 }

--- a/src/internal/generator/types.rs
+++ b/src/internal/generator/types.rs
@@ -49,16 +49,16 @@ pub fn remove_reserved_identifier(name: &str) -> String {
     name.into()
 }
 pub fn to_rust_module_name(name: &str) -> String {
-    name.to_case(Case::Snake)
+    remove_reserved_identifier(name).to_case(Case::Snake)
 }
 
 pub fn to_rust_type_name(name: &str) -> String {
-    name.to_case(Case::UpperCamel)
+    remove_reserved_identifier(name).to_case(Case::UpperCamel)
 }
 
 /// Translates a zserio name to a rust constant name.
 pub fn to_rust_constant_name(name: &str) -> String {
-    name.to_ascii_uppercase()
+    remove_reserved_identifier(name).to_ascii_uppercase()
 }
 
 pub fn convert_field_name(name: &str) -> String {


### PR DESCRIPTION
- In case the zserio path was like "test._module", the folder structure would be "test/_module", but the module tree would use "test::module" (missing the underscore).
- This little PR fixes the folder naming.