### PR TITLE
Fix Generation of Complex Dot Expressions

### DIFF
--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -48,6 +48,7 @@ pub fn get_array_trait_for_type(zserio_type: &TypeReference) -> String {
 }
 
 pub fn initialize_array_trait(
+    scope: &ModelScope,
     type_generator: &TypeGenerator,
     zserio_type: &TypeReference,
 ) -> String {
@@ -62,7 +63,7 @@ pub fn initialize_array_trait(
         if let Some(length_expression) = &zserio_type.length_expression {
             code_str += format!(
                 "num_bits: ({}) as u8,\n",
-                generate_expression(&length_expression.borrow(), type_generator)
+                generate_expression(&length_expression.borrow(), type_generator, scope)
             )
             .as_str();
         } else {
@@ -114,12 +115,12 @@ pub fn instantiate_zserio_array(
     ));
     function.line(format!(
         "array_trait: Box::new({}),",
-        initialize_array_trait(type_generator, fund_type.as_ref())
+        initialize_array_trait(scope, type_generator, fund_type.as_ref())
     ));
     let array_length_str = match &field.array.as_ref().unwrap().array_length_expression {
         Some(array_length_expression) => format!(
             "Some(({}) as usize)",
-            generate_expression(&array_length_expression.borrow(), type_generator)
+            generate_expression(&array_length_expression.borrow(), type_generator, scope)
         ),
         None => "None".to_owned(),
     };

--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -10,7 +10,7 @@ use codegen::Function;
 use crate::internal::generator::{array::array_type_name, array::initialize_array_trait};
 
 pub fn bitsize_type_reference(
-    _scope: &ModelScope,
+    scope: &ModelScope,
     type_generator: &TypeGenerator,
     function: &mut Function,
     field_name: &str,
@@ -56,7 +56,7 @@ pub fn bitsize_type_reference(
             function.line(format!(
                 "end_position += context_node.children[{}].context.as_mut().unwrap().bitsize_of(&{}, end_position, &{});",
                 node_idx,
-                initialize_array_trait(type_generator, type_reference),
+                initialize_array_trait(scope, type_generator, type_reference),
                 field_name,
             ));
         } else {
@@ -123,7 +123,7 @@ pub fn bitsize_field(
     if let Some(optional_clause) = &field.optional_clause {
         function.line(format!(
             "if {} {{",
-            generate_boolean_expression(&optional_clause.borrow(), type_generator)
+            generate_boolean_expression(&optional_clause.borrow(), type_generator, scope)
         ));
     }
 

--- a/src/internal/generator/decode.rs
+++ b/src/internal/generator/decode.rs
@@ -66,7 +66,7 @@ pub fn decode_type(
             function.line(format!(
                 "context_node.children[{}].context.as_mut().unwrap().read(&{}, reader, &mut {}, 0);",
                 node_idx,
-                initialize_array_trait(type_generator, &fund_type),
+                initialize_array_trait(scope, type_generator, &fund_type),
                 rvalue_field_name,
             ));
         } else {
@@ -74,8 +74,11 @@ pub fn decode_type(
             if fund_type.bits != 0 || fund_type.length_expression.is_some() {
                 let bit_length_string = match &fund_type.length_expression {
                     Some(bit_length_expression) => {
-                        let mut length_expression_string =
-                            generate_expression(&bit_length_expression.borrow(), type_generator);
+                        let mut length_expression_string = generate_expression(
+                            &bit_length_expression.borrow(),
+                            type_generator,
+                            scope,
+                        );
                         // check if there is a typecast needed
                         if let Some(native_type) = &bit_length_expression.borrow().native_type {
                             if native_type.name != "uint8" {
@@ -128,7 +131,7 @@ pub fn decode_field(
     if let Some(optional_clause) = &field.optional_clause {
         function.line(format!(
             "if {} {{",
-            generate_boolean_expression(&optional_clause.borrow(), type_generator)
+            generate_boolean_expression(&optional_clause.borrow(), type_generator, scope)
         ));
     }
 
@@ -234,7 +237,7 @@ pub fn decode_field(
             }
             let mut rvalue = format!(
                 "{}{}",
-                generate_expression(&type_argument, type_generator),
+                generate_expression(&type_argument, type_generator, scope),
                 requires_cloning
             );
 

--- a/src/internal/generator/encode.rs
+++ b/src/internal/generator/encode.rs
@@ -59,14 +59,14 @@ pub fn encode_type(
             function.line(format!(
                 "context_node.children[{}].context.as_mut().unwrap().write(&{}, writer, &{});",
                 node_idx,
-                initialize_array_trait(type_generator, &fund_type),
+                initialize_array_trait(scope, type_generator, &fund_type),
                 field_name,
             ));
         } else if fund_type.bits != 0 || fund_type.length_expression.is_some() {
             let bit_length_string = match &fund_type.length_expression {
                 Some(bit_length_expression) => {
                     let mut length_expression_string =
-                        generate_expression(&bit_length_expression.borrow(), type_generator);
+                        generate_expression(&bit_length_expression.borrow(), type_generator, scope);
                     // check if there is a typecast needed
                     if let Some(native_type) = &bit_length_expression.borrow().native_type {
                         if native_type.name != "uint8" {
@@ -128,7 +128,7 @@ pub fn encode_field(
     if let Some(optional_clause) = &field.optional_clause {
         function.line(format!(
             "if {} {{",
-            generate_boolean_expression(&optional_clause.borrow(), type_generator)
+            generate_boolean_expression(&optional_clause.borrow(), type_generator, scope)
         ));
     }
 
@@ -198,7 +198,7 @@ pub fn encode_field(
             // the caller.
 
             // Check if casts are needed.
-            let mut rvalue = generate_expression(&type_argument, type_generator);
+            let mut rvalue = generate_expression(&type_argument, type_generator, scope);
             if expression_requires_cast(
                 &type_parameter.borrow().zserio_type,
                 type_generator,
@@ -230,7 +230,7 @@ pub fn encode_field(
             function.line(format!(
                 "assert!({}.len() == ({}) as usize);",
                 &field_name,
-                &generate_expression(&array_length_expr.borrow(), type_generator),
+                &generate_expression(&array_length_expr.borrow(), type_generator, scope),
             ));
         }
 

--- a/src/internal/generator/function.rs
+++ b/src/internal/generator/function.rs
@@ -1,9 +1,11 @@
 use crate::internal::ast::zfunction::ZFunction;
+use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::expression::generate_expression;
 use crate::internal::generator::types::{convert_to_function_name, TypeGenerator};
 use codegen::Impl;
 
 pub fn generate_function(
+    scope: &ModelScope,
     codegen_scope: &mut Impl,
     type_generator: &TypeGenerator,
     zserio_function: &ZFunction,
@@ -27,13 +29,21 @@ pub fn generate_function(
     {
         fn_gen_scope.line(format!(
             "{}.clone()",
-            generate_expression(&zserio_function.result.as_ref().borrow(), type_generator),
+            generate_expression(
+                &zserio_function.result.as_ref().borrow(),
+                type_generator,
+                scope
+            ),
         ));
     } else {
         // Generate the function content.
         fn_gen_scope.line(format!(
             "({}) as {}",
-            generate_expression(&zserio_function.result.as_ref().borrow(), type_generator),
+            generate_expression(
+                &zserio_function.result.as_ref().borrow(),
+                type_generator,
+                scope
+            ),
             type_generator.ztype_to_rust_type(&zserio_function.return_type),
         ));
     }

--- a/src/internal/generator/packed_contexts.rs
+++ b/src/internal/generator/packed_contexts.rs
@@ -125,7 +125,7 @@ pub fn generate_init_packed_context_for_field(
     if let Some(optional_clause) = &field_details.field.borrow().optional_clause {
         fn_gen.line(format!(
             "if {} {{",
-            generate_boolean_expression(&optional_clause.borrow(), type_generator)
+            generate_boolean_expression(&optional_clause.borrow(), type_generator, model_scope)
         ));
     }
 
@@ -159,7 +159,11 @@ pub fn generate_init_packed_context_for_field(
         fn_gen.line(format!(
             "{}_delta_context.init(&{}, &{});",
             &field_details.field_context_node_name,
-            initialize_array_trait(type_generator, &field_details.native_type.fundamental_type),
+            initialize_array_trait(
+                model_scope,
+                type_generator,
+                &field_details.native_type.fundamental_type
+            ),
             &field_name
         ));
     }

--- a/src/internal/generator/zbitmask.rs
+++ b/src/internal/generator/zbitmask.rs
@@ -90,7 +90,7 @@ pub fn generate_bitmask(
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
     init_packing_context_fn.line(format!("context_node.children[0].context.as_mut().unwrap().init(&{}, &(self.bitmask_value as {}));", 
-        &initialize_array_trait(type_generator, &fundamental_type.fundamental_type),
+        &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &bitmask_rust_type,
     ));
 

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -131,7 +131,12 @@ pub fn generate_choice(
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);
     for zserio_function in &zchoice.functions {
-        generate_function(pub_impl, type_generator, &zserio_function.as_ref().borrow());
+        generate_function(
+            symbol_scope,
+            pub_impl,
+            type_generator,
+            &zserio_function.as_ref().borrow(),
+        );
     }
 
     write_to_file(
@@ -161,6 +166,7 @@ pub fn generate_choice_match_construct(
             case_expressions.push(generate_expression(
                 &case_expr.as_ref().borrow(),
                 type_generator,
+                symbol_scope,
             ));
         }
         let selector_expression_evaluation = case_expressions.join(" | ");

--- a/src/internal/generator/zconst.rs
+++ b/src/internal/generator/zconst.rs
@@ -46,7 +46,11 @@ pub fn generate_constant(
         "pub const {}: {} = {};\n",
         to_rust_constant_name(&zconst.name),
         field_type,
-        generate_expression(&zconst.value_expression.borrow(), type_generator),
+        generate_expression(
+            &zconst.value_expression.borrow(),
+            type_generator,
+            symbol_scope
+        ),
     )
     .as_str();
 

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -104,7 +104,7 @@ pub fn generate_enum(
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
     init_packing_context_fn.line(format!(
         "context_node.children[0].context.as_mut().unwrap().init(&{}, &(*self as {}));",
-        &initialize_array_trait(type_generator, &fundamental_type.fundamental_type),
+        &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &rust_type_type,
     ));
 

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -127,7 +127,12 @@ pub fn generate_struct(
     // Generate all the zserio functions (defined in the zserio language).
     let pub_impl = codegen_scope.new_impl(&rust_type_name);
     for zserio_function in &zstruct.functions {
-        generate_function(pub_impl, type_generator, &zserio_function.as_ref().borrow());
+        generate_function(
+            symbol_scope,
+            pub_impl,
+            type_generator,
+            &zserio_function.as_ref().borrow(),
+        );
     }
 
     write_to_file(

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -157,7 +157,12 @@ pub fn generate_union(
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);
     for zserio_function in &zunion.functions {
-        generate_function(pub_impl, type_generator, &zserio_function.as_ref().borrow());
+        generate_function(
+            symbol_scope,
+            pub_impl,
+            type_generator,
+            &zserio_function.as_ref().borrow(),
+        );
     }
 
     write_to_file(

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -22,3 +22,4 @@ import reference_modules.packed_arrays.packed_arrays.*;
 import reference_modules.subtyped_dot_expression.subtyped_enum.*;
 import reference_modules.subtyped_dot_expression.test_enum.*;
 import reference_modules.subtyped_dot_expression.test.*;
+import reference_modules.complex_dot_expression.complex_dot_expression.*;

--- a/tests/reference_modules/complex_dot_expression/complex_dot_expression.zs
+++ b/tests/reference_modules/complex_dot_expression/complex_dot_expression.zs
@@ -1,0 +1,25 @@
+package reference_modules.complex_dot_expression.complex_dot_expression;
+
+bitmask uint8 SomeBitMask
+{
+    HAS_A,
+    HAS_B = 0x04,
+    HAS_C,
+};
+
+struct InnerStruct {
+    SomeBitMask selector_bitmask;
+};
+
+struct MiddleStruct {
+    InnerStruct value;
+};
+
+struct OuterStruct {
+    MiddleStruct value;
+};
+
+struct TestStruct {
+    OuterStruct value;
+    int32 optValue if value.value.value.selector_bitmask == SomeBitMask.HAS_A;
+};


### PR DESCRIPTION
- The code generator so far failed to generate complex, multi-level
  dot expressions, such as:

`<struct>.<field>.<other_field>.<enum_field>.<enum_item>`

- So far, such expressions failed to generate. This PR fixes this.
- Additionally, expressions that use bitfields would be generated
  incorrectly. For example:

 `<struct>.<bitfield_field> = <bitfield_value>`

  would fail due to the way bitmask types are implemented (using
  a wrapper struct).
  To solve this issue, the generation code was changes as follows:

`<struct>.<bitfield_field>.bitfield_value = <bitfield_value>`