### PR TITLE
Cache Converted Names/Types for Performance Improvements

### DIFF
--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -49,7 +49,7 @@ pub fn get_array_trait_for_type(zserio_type: &TypeReference) -> String {
 
 pub fn initialize_array_trait(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     zserio_type: &TypeReference,
 ) -> String {
     let mut code_str = format!(
@@ -94,7 +94,7 @@ pub fn initialize_array_trait(
 
 pub fn instantiate_zserio_array(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     field: &Field,
     force_packed: bool,

--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -4,14 +4,14 @@ use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::encode::requires_borrowing;
 use crate::internal::generator::expression::generate_boolean_expression;
-use crate::internal::generator::types::{convert_field_name, TypeGenerator};
+use crate::internal::generator::types::TypeGenerator;
 use codegen::Function;
 
 use crate::internal::generator::{array::array_type_name, array::initialize_array_trait};
 
 pub fn bitsize_type_reference(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     field_name: &str,
     is_marshaler: bool,
@@ -111,13 +111,13 @@ pub fn bitsize_type_reference(
 
 pub fn bitsize_field(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     field: &Field,
     context_node_index: Option<u8>,
 ) {
     let native_type = get_fundamental_type(&field.field_type, scope);
-    let mut field_name = format!("self.{}", convert_field_name(&field.name));
+    let mut field_name = format!("self.{}", type_generator.convert_field_name(&field.name));
 
     // Check if the field uses an optional clause
     if let Some(optional_clause) = &field.optional_clause {
@@ -139,7 +139,7 @@ pub fn bitsize_field(
         function.line("end_position += 1;");
         // If the type is a marshaller, take it by reference.
         let mut borrow_symbol = String::from("");
-        if requires_borrowing(&native_type) {
+        if requires_borrowing(field, &native_type) {
             borrow_symbol = "&".into();
         }
 

--- a/src/internal/generator/casts.rs
+++ b/src/internal/generator/casts.rs
@@ -5,7 +5,7 @@ use crate::internal::generator::types::TypeGenerator;
 pub fn requires_cast(
     target_type: &TypeReference,
     other_type: &TypeReference,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
 ) -> bool {
     let other_rust_type = type_generator.ztype_to_rust_type(other_type);
     let target_rust_type = type_generator.ztype_to_rust_type(target_type);
@@ -14,7 +14,7 @@ pub fn requires_cast(
 
 pub fn expression_requires_cast(
     target_type: &TypeReference,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     expression: &Expression,
 ) -> bool {
     match &expression.result_type {

--- a/src/internal/generator/decode.rs
+++ b/src/internal/generator/decode.rs
@@ -9,13 +9,13 @@ use crate::internal::ast::{field::Field, type_reference::TypeReference};
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::new::get_default_initializer;
-use crate::internal::generator::types::{convert_field_name, TypeGenerator};
+use crate::internal::generator::types::TypeGenerator;
 
 use crate::internal::generator::array::{array_type_name, initialize_array_trait};
 
 pub fn decode_type(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     lvalue_field_name: &String,
     rvalue_field_name: &String,
@@ -115,13 +115,13 @@ pub fn decode_type(
 
 pub fn decode_field(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     field: &Field,
     context_node_index: Option<u8>,
 ) {
     let native_type = get_fundamental_type(&field.field_type, scope);
-    let field_name = convert_field_name(&field.name);
+    let field_name = type_generator.convert_field_name(&field.name);
     let mut rvalue_field_name = format!("self.{}", field_name);
     let mut lvalue_field_name = rvalue_field_name.clone();
     let raw_field_type = type_generator.ztype_to_rust_type(&field.field_type);
@@ -256,7 +256,7 @@ pub fn decode_field(
             function.line(format!(
                 "{}.{} = {};",
                 element_name,
-                convert_field_name(&type_parameter.borrow().name),
+                type_generator.convert_field_name(&type_parameter.borrow().name),
                 rvalue,
             ));
         }
@@ -287,7 +287,7 @@ pub fn decode_field(
     if field.is_optional {
         function.line(format!(
             "self.{} = Option::from(optional_value);",
-            convert_field_name(&field.name)
+            type_generator.convert_field_name(&field.name)
         ));
         function.line("}"); // close the "if present {"
     }

--- a/src/internal/generator/file_generator.rs
+++ b/src/internal/generator/file_generator.rs
@@ -1,10 +1,16 @@
-use crate::internal::generator::types::to_rust_module_name;
+use crate::internal::generator::types::TypeGenerator;
 use rust_format::{Formatter, RustFmt};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-pub fn write_to_file(content: &String, root_path: &Path, zserio_pkg_name: &str, file_name: &str) {
+pub fn write_to_file(
+    type_generator: &mut TypeGenerator,
+    content: &String,
+    root_path: &Path,
+    zserio_pkg_name: &str,
+    file_name: &str,
+) {
     let format_result = RustFmt::default().format_str(content);
     if format_result.is_err() {
         panic!(
@@ -18,7 +24,7 @@ pub fn write_to_file(content: &String, root_path: &Path, zserio_pkg_name: &str, 
 
     let mut file_path = root_path.to_owned();
     for dir in String::from(zserio_pkg_name).split('.') {
-        file_path = file_path.join(to_rust_module_name(dir));
+        file_path = file_path.join(type_generator.to_rust_module_name(dir));
     }
     fs::create_dir_all(file_path.as_path()).expect("mkdir failed");
     let filename = file_path.join(String::from(file_name) + ".rs");

--- a/src/internal/generator/function.rs
+++ b/src/internal/generator/function.rs
@@ -7,7 +7,7 @@ use codegen::Impl;
 pub fn generate_function(
     scope: &ModelScope,
     codegen_scope: &mut Impl,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     zserio_function: &ZFunction,
 ) {
     // Generates a rust function for a zserio function.

--- a/src/internal/generator/mod_file.rs
+++ b/src/internal/generator/mod_file.rs
@@ -1,5 +1,5 @@
 use crate::internal::generator::file_generator::write_to_file;
-use crate::internal::generator::types::to_rust_module_name;
+use crate::internal::generator::types::TypeGenerator;
 use crate::internal::model::Model;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -10,11 +10,15 @@ struct ZserioModuleTreeNode {
     children: HashMap<String, Rc<RefCell<ZserioModuleTreeNode>>>,
 }
 
-fn add_package_to_tree(tree_node: &Rc<RefCell<ZserioModuleTreeNode>>, pkg_name: &str) {
+fn add_package_to_tree(
+    type_generator: &mut TypeGenerator,
+    tree_node: &Rc<RefCell<ZserioModuleTreeNode>>,
+    pkg_name: &str,
+) {
     let mut current_node: Rc<RefCell<ZserioModuleTreeNode>> = tree_node.clone();
     //let mut current_node = tree_node;
     for module_path in pkg_name.split('.') {
-        let rust_module_name = to_rust_module_name(module_path);
+        let rust_module_name = type_generator.to_rust_module_name(module_path);
 
         if let Some(child_node) = current_node
             .clone()
@@ -68,14 +72,19 @@ fn generate_mod_section(
 
 /// This function generates the top-level mod file, which adds all generated packages
 /// to the known packages.
-pub fn generate_top_level_mod_file(model: &Model, package_directory: &Path, root_package: &str) {
+pub fn generate_top_level_mod_file(
+    type_generator: &mut TypeGenerator,
+    model: &Model,
+    package_directory: &Path,
+    root_package: &str,
+) {
     // Reorganize the packages into a tree structure, categorized by module.
     let module_tree_root = Rc::from(RefCell::from(ZserioModuleTreeNode {
         children: HashMap::new(),
     }));
 
     for package in model.packages.values() {
-        add_package_to_tree(&module_tree_root, &package.name);
+        add_package_to_tree(type_generator, &module_tree_root, &package.name);
     }
 
     // Generate the mod.rs file content.
@@ -96,5 +105,11 @@ pub fn generate_top_level_mod_file(model: &Model, package_directory: &Path, root
         filename = "lib";
     }
 
-    write_to_file(&mod_file_content, package_directory, "", filename);
+    write_to_file(
+        type_generator,
+        &mod_file_content,
+        package_directory,
+        "",
+        filename,
+    );
 }

--- a/src/internal/generator/model.rs
+++ b/src/internal/generator/model.rs
@@ -1,15 +1,19 @@
 use crate::internal::generator::mod_file::generate_top_level_mod_file;
 use crate::internal::generator::package::generate_package;
+use crate::internal::generator::types::TypeGenerator;
+
 use crate::internal::model::Model;
 use std::path::Path;
 
 pub fn generate_model(model: &mut Model, package_directory: &Path, root_package: &str) {
+    let mut type_generator = TypeGenerator::new(root_package.to_owned());
+
     let scope = &mut model.scope;
     // Generate the rust interface files for all packages.
     for package in model.packages.values() {
-        generate_package(scope, package, package_directory, root_package);
+        generate_package(&mut type_generator, scope, package, package_directory);
     }
 
     // Generate the overall mod file.
-    generate_top_level_mod_file(model, package_directory, root_package);
+    generate_top_level_mod_file(&mut type_generator, model, package_directory, root_package);
 }

--- a/src/internal/generator/new.rs
+++ b/src/internal/generator/new.rs
@@ -5,11 +5,11 @@ use crate::internal::ast::{field::Array, field::Field, parameter::Parameter};
 use crate::internal::ast::type_reference::TypeReference;
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::ModelScope;
-use crate::internal::generator::types::{convert_field_name, TypeGenerator};
+use crate::internal::generator::types::TypeGenerator;
 
 pub fn new_field(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     field: &Field,
 ) {
@@ -26,7 +26,7 @@ pub fn new_field(
 
 pub fn new_param(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     param: &Parameter,
 ) {
@@ -75,7 +75,7 @@ pub fn get_default_initializer(
 }
 pub fn new_type(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     function: &mut Function,
     name: &str,
     type_reference: &TypeReference,
@@ -84,7 +84,7 @@ pub fn new_type(
 ) {
     let native_type = get_fundamental_type(type_reference, scope);
     let fund_type = native_type.fundamental_type;
-    let field_name = convert_field_name(name);
+    let field_name = type_generator.convert_field_name(name);
     let rust_type = type_generator.ztype_to_rust_type(type_reference);
 
     function.line(format!(

--- a/src/internal/generator/package.rs
+++ b/src/internal/generator/package.rs
@@ -10,16 +10,13 @@ use codegen::Scope;
 use std::path::Path;
 
 pub fn generate_package(
+    type_generator: &mut TypeGenerator,
     symbol_scope: &ModelScope,
     package: &ZPackage,
     package_directory: &Path,
-    root_package: &str,
 ) {
     let package_name = &package.name;
     let mut module_names = Vec::new();
-    let type_generator = TypeGenerator {
-        root_package_name: root_package.to_owned(),
-    };
 
     // Generate  the rust code for zserio structures.
     for z_struct_ref_cell in package.structs.values() {
@@ -31,7 +28,7 @@ pub fn generate_package(
         let mut gen_scope = Scope::new();
         module_names.push(generate_struct(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut gen_scope,
             &z_struct,
             package_directory,
@@ -49,7 +46,7 @@ pub fn generate_package(
         let mut gen_scope = Scope::new();
         module_names.push(generate_choice(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut gen_scope,
             &z_choice,
             package_directory,
@@ -67,7 +64,7 @@ pub fn generate_package(
         let mut gen_scope = Scope::new();
         module_names.push(generate_union(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut gen_scope,
             &zunion,
             package_directory,
@@ -81,7 +78,7 @@ pub fn generate_package(
         let mut gen_scope = Scope::new();
         module_names.push(generate_enum(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut gen_scope,
             &z_enum,
             package_directory,
@@ -95,7 +92,7 @@ pub fn generate_package(
         let mut gen_scope = Scope::new();
         module_names.push(generate_bitmask(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut gen_scope,
             &zbitmask,
             package_directory,
@@ -113,7 +110,7 @@ pub fn generate_package(
         let mut codegen_scope = Scope::new();
         module_names.push(generate_subtype(
             &mut codegen_scope,
-            &type_generator,
+            type_generator,
             &zsubtype,
             package_directory,
             package_name,
@@ -126,7 +123,7 @@ pub fn generate_package(
         let mut codegen_scope = Scope::new();
         module_names.push(generate_constant(
             symbol_scope,
-            &type_generator,
+            type_generator,
             &mut codegen_scope,
             &zconst,
             package_directory,
@@ -149,5 +146,11 @@ pub fn generate_package(
         mod_file_content += format!("pub mod {};\n", module_name).as_str();
     }
 
-    write_to_file(&mod_file_content, package_directory, package_name, "mod");
+    write_to_file(
+        type_generator,
+        &mod_file_content,
+        package_directory,
+        package_name,
+        "mod",
+    );
 }

--- a/src/internal/generator/packed_contexts.rs
+++ b/src/internal/generator/packed_contexts.rs
@@ -6,9 +6,7 @@ use crate::internal::compiler::fundamental_type::{
 };
 use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
 use crate::internal::generator::encode::requires_borrowing;
-use crate::internal::generator::{
-    expression::generate_boolean_expression, types::convert_field_name, types::TypeGenerator,
-};
+use crate::internal::generator::{expression::generate_boolean_expression, types::TypeGenerator};
 use codegen::Function;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -29,10 +27,10 @@ impl FieldDetails {
         field_rc: &Rc<RefCell<Field>>,
         field_index: usize,
         symbol_scope: &ModelScope,
-        type_generator: &TypeGenerator,
+        type_generator: &mut TypeGenerator,
     ) -> Self {
         let field = &field_rc.borrow();
-        let field_name = convert_field_name(&field.name);
+        let field_name = type_generator.convert_field_name(&field.name);
         let field_context_node_name = format!("field_{}_node", &field_name);
 
         FieldDetails {
@@ -114,7 +112,7 @@ pub fn generate_packed_context_for_field(
 
 pub fn generate_init_packed_context_for_field(
     model_scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     fn_gen: &mut Function,
     field_details: &FieldDetails,
 ) {
@@ -134,7 +132,7 @@ pub fn generate_init_packed_context_for_field(
     if field_details.field.borrow().is_optional {
         // If the type is a marshaller, take it by reference.
         let mut borrow_symbol = String::from("");
-        if requires_borrowing(&field_details.native_type) {
+        if requires_borrowing(&field_details.field.borrow(), &field_details.native_type) {
             borrow_symbol = "&".into();
         }
 

--- a/src/internal/generator/subtype.rs
+++ b/src/internal/generator/subtype.rs
@@ -1,27 +1,28 @@
 use crate::internal::ast::zsubtype::Subtype;
 use crate::internal::generator::file_generator::write_to_file;
 use crate::internal::generator::preamble::add_standard_imports;
-use crate::internal::generator::types::{to_rust_module_name, to_rust_type_name, TypeGenerator};
+use crate::internal::generator::types::TypeGenerator;
 use codegen::Scope;
 use std::path::Path;
 
 pub fn generate_subtype(
     codegen_scope: &mut Scope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     subtype: &Subtype,
     path: &Path,
     package_name: &str,
 ) -> String {
     add_standard_imports(codegen_scope);
 
-    let rust_module_name = to_rust_module_name(&subtype.name);
+    let rust_module_name = type_generator.to_rust_module_name(&subtype.name);
     let type_alias_scope = codegen_scope.new_type_alias(
-        to_rust_type_name(&subtype.name),
+        type_generator.to_rust_type_name(&subtype.name),
         &type_generator.ztype_to_rust_type(&subtype.zserio_type),
     );
     type_alias_scope.vis("pub");
 
     write_to_file(
+        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,

--- a/src/internal/generator/zbitmask.rs
+++ b/src/internal/generator/zbitmask.rs
@@ -6,21 +6,20 @@ use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::{
     array::initialize_array_trait, bitsize::bitsize_type_reference, decode::decode_type,
     encode::encode_type, file_generator::write_to_file, preamble::add_standard_imports,
-    types::to_rust_constant_name, types::to_rust_module_name, types::to_rust_type_name,
-    types::zserio_to_rust_type, types::TypeGenerator,
+    types::to_rust_constant_name, types::zserio_to_rust_type, types::TypeGenerator,
 };
 use std::path::Path;
 
 pub fn generate_bitmask(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     gen_scope: &mut Scope,
     zbitmask: &ZBitmaskType,
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = to_rust_module_name(&zbitmask.name);
-    let rust_type_name = to_rust_type_name(&zbitmask.name);
+    let rust_module_name = type_generator.to_rust_module_name(&zbitmask.name);
+    let rust_type_name = type_generator.to_rust_type_name(&zbitmask.name);
     let fundamental_type = get_fundamental_type(&zbitmask.zserio_type, scope);
     let bitmask_rust_type = type_generator.ztype_to_rust_type(&fundamental_type.fundamental_type);
 
@@ -96,13 +95,19 @@ pub fn generate_bitmask(
 
     file_content += new_scope.to_string().as_str();
 
-    write_to_file(&file_content, path, package_name, &rust_module_name);
+    write_to_file(
+        type_generator,
+        &file_content,
+        path,
+        package_name,
+        &rust_module_name,
+    );
     rust_module_name
 }
 
 fn generate_zserio_read(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     impl_codegen: &mut codegen::Impl,
     zbitmask: &ZBitmaskType,
 ) {
@@ -145,7 +150,7 @@ fn generate_zserio_read(
 
 fn generate_zserio_write(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     impl_codegen: &mut codegen::Impl,
     zbitmask: &ZBitmaskType,
 ) {
@@ -179,7 +184,7 @@ fn generate_zserio_write(
 
 fn generate_zserio_bitsize(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     impl_codegen: &mut codegen::Impl,
     zbitmask: &ZBitmaskType,
 ) {

--- a/src/internal/generator/zconst.rs
+++ b/src/internal/generator/zconst.rs
@@ -4,22 +4,20 @@ use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::expression::generate_expression;
 use crate::internal::generator::file_generator::write_to_file;
 use crate::internal::generator::preamble::add_standard_imports;
-use crate::internal::generator::{
-    types::to_rust_constant_name, types::to_rust_module_name, types::TypeGenerator,
-};
+use crate::internal::generator::{types::to_rust_constant_name, types::TypeGenerator};
 use std::path::Path;
 
 use codegen::Scope;
 
 pub fn generate_constant(
     symbol_scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     codegen_scope: &mut Scope,
     zconst: &ZConst,
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = to_rust_module_name(&zconst.name);
+    let rust_module_name = type_generator.to_rust_module_name(&zconst.name);
 
     add_standard_imports(codegen_scope);
 
@@ -54,6 +52,12 @@ pub fn generate_constant(
     )
     .as_str();
 
-    write_to_file(&file_content, path, package_name, &rust_module_name);
+    write_to_file(
+        type_generator,
+        &file_content,
+        path,
+        package_name,
+        &rust_module_name,
+    );
     rust_module_name
 }

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -6,21 +6,20 @@ use crate::internal::compiler::symbol_scope::ModelScope;
 use crate::internal::generator::{
     array::initialize_array_trait, bitsize::bitsize_type_reference, decode::decode_type,
     encode::encode_type, file_generator::write_to_file, preamble::add_standard_imports,
-    types::convert_to_enum_field_name, types::to_rust_module_name, types::to_rust_type_name,
-    types::zserio_to_rust_type, types::TypeGenerator,
+    types::convert_to_enum_field_name, types::zserio_to_rust_type, types::TypeGenerator,
 };
 use std::path::Path;
 
 pub fn generate_enum(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     gen_scope: &mut Scope,
     zenum: &ZEnum,
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = to_rust_module_name(&zenum.name);
-    let rust_type_name = to_rust_type_name(&zenum.name);
+    let rust_module_name = type_generator.to_rust_module_name(&zenum.name);
+    let rust_type_name = type_generator.to_rust_type_name(&zenum.name);
     let fundamental_type = get_fundamental_type(&zenum.enum_type, scope);
     let rust_type_type = type_generator.ztype_to_rust_type(&fundamental_type.fundamental_type);
 
@@ -109,6 +108,7 @@ pub fn generate_enum(
     ));
 
     write_to_file(
+        type_generator,
         &gen_scope.to_string(),
         path,
         package_name,
@@ -119,11 +119,11 @@ pub fn generate_enum(
 
 fn generate_zserio_read(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     struct_impl: &mut codegen::Impl,
     zenum: &ZEnum,
 ) {
-    let rust_type_name = to_rust_type_name(&zenum.name);
+    let rust_type_name = type_generator.to_rust_type_name(&zenum.name);
     let zserio_read_fn = struct_impl.new_fn("zserio_read");
     zserio_read_fn.arg_mut_self();
     zserio_read_fn.arg("reader", "&mut BitReader");
@@ -163,7 +163,7 @@ fn generate_zserio_read(
 
 fn generate_zserio_write(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     impl_codegen: &mut codegen::Impl,
     zenum: &ZEnum,
 ) {
@@ -200,7 +200,7 @@ fn generate_zserio_write(
 
 fn generate_zserio_bitsize(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     impl_codegen: &mut codegen::Impl,
     zenum: &ZEnum,
 ) {

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -6,8 +6,7 @@ use crate::internal::generator::{
     file_generator::write_to_file, function::generate_function, new::new_field, new::new_param,
     packed_contexts::generate_init_packed_context_for_field,
     packed_contexts::generate_packed_context_for_field, packed_contexts::FieldDetails,
-    preamble::add_standard_imports, types::convert_field_name, types::to_rust_module_name,
-    types::to_rust_type_name, types::TypeGenerator,
+    preamble::add_standard_imports, types::TypeGenerator,
 };
 use codegen::Scope;
 use codegen::Struct;
@@ -29,14 +28,14 @@ pub fn generate_struct_member_for_field(gen_struct: &mut Struct, field: &FieldDe
 
 pub fn generate_struct(
     symbol_scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     codegen_scope: &mut Scope,
     zstruct: &ZStruct,
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = to_rust_module_name(&zstruct.name);
-    let rust_type_name = to_rust_type_name(&zstruct.name);
+    let rust_module_name = type_generator.to_rust_module_name(&zstruct.name);
+    let rust_type_name = type_generator.to_rust_type_name(&zstruct.name);
 
     let mut field_details = vec![];
     for (field_index, field_rc) in zstruct.fields.iter().enumerate() {
@@ -66,7 +65,7 @@ pub fn generate_struct(
         // painful in rust due to the lifetime checks.
         // Because I am lazy, this implementation will just copy values over.
         let gen_param_field = gen_struct.new_field(
-            convert_field_name(&param.as_ref().borrow().name),
+            type_generator.convert_field_name(&param.as_ref().borrow().name),
             param_type,
         );
         gen_param_field.vis("pub");
@@ -136,6 +135,7 @@ pub fn generate_struct(
     }
 
     write_to_file(
+        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,
@@ -146,7 +146,7 @@ pub fn generate_struct(
 
 fn generate_zserio_read(
     scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<FieldDetails>,
 ) {
@@ -194,7 +194,7 @@ fn generate_zserio_read(
 
 fn generate_zserio_write(
     symbol_scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<FieldDetails>,
 ) {
@@ -232,7 +232,7 @@ fn generate_zserio_write(
 
 fn generate_zserio_bitsize(
     symbol_scope: &ModelScope,
-    type_generator: &TypeGenerator,
+    type_generator: &mut TypeGenerator,
     struct_impl: &mut codegen::Impl,
     fields: &Vec<FieldDetails>,
 ) {


### PR DESCRIPTION
- So far, the main performance bottleneck was the string translations and case conversions used for the zserio names and types, e.g. `fieldName` to `field_name`, or filtering out keywords resevered by the language.
- This PR enhances the type converter class by a cache, where previous conversion results can be stored in a map, to retrieve them, if the same name/field/type is converted again.