### PR TITLE
Fix Compile Errors in Optional Arrays

### DIFF
--- a/src/internal/generator/bitsize.rs
+++ b/src/internal/generator/bitsize.rs
@@ -139,7 +139,7 @@ pub fn bitsize_field(
         function.line("end_position += 1;");
         // If the type is a marshaller, take it by reference.
         let mut borrow_symbol = String::from("");
-        if requires_borrowing(&native_type) {
+        if requires_borrowing(field, &native_type) {
             borrow_symbol = "&".into();
         }
 

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -213,9 +213,6 @@ fn generate_dot_expression(
     let op1 = expression.operand1.as_ref().unwrap();
     let op2 = expression.operand2.as_ref().unwrap();
 
-    if expression.operand2.as_ref().unwrap().text == "selector_bitmask" {
-        print!("test {:?}", expression.symbol.as_ref().unwrap());
-    }
     return match &op1.result_type {
         ExpressionType::Enum(_) => {
             let expr_symbol = op1.symbol.as_ref().unwrap();

--- a/src/internal/generator/packed_contexts.rs
+++ b/src/internal/generator/packed_contexts.rs
@@ -134,7 +134,7 @@ pub fn generate_init_packed_context_for_field(
     if field_details.field.borrow().is_optional {
         // If the type is a marshaller, take it by reference.
         let mut borrow_symbol = String::from("");
-        if requires_borrowing(&field_details.native_type) {
+        if requires_borrowing(&field_details.field.borrow(), &field_details.native_type) {
             borrow_symbol = "&".into();
         }
 

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -23,3 +23,4 @@ import reference_modules.subtyped_dot_expression.subtyped_enum.*;
 import reference_modules.subtyped_dot_expression.test_enum.*;
 import reference_modules.subtyped_dot_expression.test.*;
 import reference_modules.complex_dot_expression.complex_dot_expression.*;
+import reference_modules.optional_array.optional_array.*;

--- a/tests/reference_modules/optional_array/optional_array.zs
+++ b/tests/reference_modules/optional_array/optional_array.zs
@@ -1,0 +1,20 @@
+package reference_modules.optional_array.optional_array;
+
+subtype string CustomString;
+
+enum int32 OptionEnum {
+    HAS_A = 0,
+    HAS_B = 1,
+    HAS_C = 2,
+};
+
+struct ArrayElement(OptionEnum param) {
+    uint32 field if param == OptionEnum.HAS_A;
+};
+
+struct OptionalArray
+{
+    OptionEnum param;
+    optional ArrayElement(param) optional_array[];
+    optional int32 int_opt_array[];
+};


### PR DESCRIPTION
The `main` branch generates invalid code, if optional arrays are used.
The problem is that arrays cannot be captures as a copy, but need to be passed by reference. This PR fixes this issue, and adds a test case. If the test case compiles, the issue is resolved.