### PR TITLE
Implement Test to compare bitsize_of() with reference python

### DIFF
--- a/src/ztype/array_traits/delta_context.rs
+++ b/src/ztype/array_traits/delta_context.rs
@@ -115,8 +115,8 @@ impl DeltaContext {
     ) -> u64 {
         if !self.processing_started {
             self.processing_started = true;
+            self.finish_init();
 
-            // self.finish_init();
             return self.bitsize_of_descriptor() + self.bitsize_of_unpacked(array_traits, element);
         }
         if !self.is_packed {

--- a/tests/compare-ref-impl-tests/rust/Cargo.toml
+++ b/tests/compare-ref-impl-tests/rust/Cargo.toml
@@ -10,3 +10,5 @@ bitreader =  "0.3.8"
 rust-bitwriter = "0.0.1"
 rust-zserio = { path = "../../.." }
 reference-module-lib = { path = "../../reference-module-lib" }
+serde_json = "1.0.107"
+serde = { version = "1.0.188", features = ["derive"] }


### PR DESCRIPTION
- This commit adds a test case to compare the `bitsize_of()` operators of zserio objects with the reference Python implementation. That way, it can be ensured that the Python reference library and the rust library behave identically in deciding whether to use packing or not.