### PR TITLE
Add a GH Action to automatically release crate when tagging a commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release rust-zserio crate
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Release using cargo publish
+      run: |
+        sed -i 's/0.0.0/${{ github.ref_name }}/g' Cargo.toml
+        cat Cargo.toml
+        cargo publish --allow-dirty
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [package]
 name = "rust-zserio"
-version = "0.0.2"
+version = "0.0.0"
 edition = "2021"
 authors = ["Clemens Zangl <clemens.zangl@gmail.com>"]
 


### PR DESCRIPTION
This PR enables an automated release pipeline of the `crate`.

Simply tagging a new version number in git should be enough, and the crate will be published.