### PR TITLE
major refactoring of `zserio` bitmask types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 antlr-rust = "0.3.0-beta"
+bitmask-enum = "2.2.4"
 bitreader =  "0.3.8"
 bitstream-io = "1.6.0"
 clap = { version="4.2.7", features = [ "derive" ] }

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -3,9 +3,7 @@ use crate::internal::ast::expression::{
 };
 use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
-use crate::internal::generator::types::{
-    convert_to_enum_field_name, to_rust_constant_name, TypeGenerator,
-};
+use crate::internal::generator::types::{convert_to_enum_field_name, TypeGenerator};
 use crate::internal::parser::gen::zserioparser::{
     AND, BANG, BINARY_LITERAL, BOOL_LITERAL, DECIMAL_LITERAL, DIVIDE, DOT, DOUBLE_LITERAL, EQ,
     FLOAT_LITERAL, GE, GT, HEXADECIMAL_LITERAL, ID, INDEX, ISSET, LBRACKET, LE, LENGTHOF,
@@ -202,6 +200,7 @@ fn is_bitmask_expression(expression: &Expression, scope: &ModelScope) -> bool {
     }
     false
 }
+
 fn generate_dot_expression(
     expression: &Expression,
     type_generator: &mut TypeGenerator,
@@ -224,25 +223,19 @@ fn generate_dot_expression(
             let bitmask_symbol = op1.symbol.as_ref().unwrap();
             let bitmask_expression = format!(
                 "{}::{}",
-                type_generator.to_rust_module_name(&bitmask_symbol.name),
-                to_rust_constant_name(&op2.text)
+                type_generator.custom_type_to_rust_type(&bitmask_symbol.name),
+                convert_to_enum_field_name(&op2.text)
             );
             type_generator.get_full_module_path(&bitmask_symbol.package, &bitmask_expression)
         }
         ExpressionType::Compound => {
             let left_operand = generate_expression(op1, type_generator, scope);
-            let mut right_side = match op2.flag {
+            let right_side = match op2.flag {
                 ExpressionFlag::IsDotExpressionRightOperand => {
                     type_generator.convert_field_name(&op2.text)
                 }
                 _ => panic!("failed to generate right side of field dot expression"),
             };
-
-            // Special handling for bitmask types. Bit masks are actually a struct, having a "bitmask"
-            // value field. Hence, when generating bit masks, this field need to be referenced as well.
-            if is_bitmask_expression(expression, scope) {
-                right_side = format!("{}.bitmask_value", right_side);
-            }
             format!("{}.{}", &left_operand, right_side,)
         }
         _ => panic!("unsupported dot expression {:?}", op1),
@@ -300,27 +293,18 @@ fn generate_identifier_expression(
 ) -> String {
     let symbol_ref = expression.symbol.as_ref().unwrap();
 
-    // Workaround for bitmasks - bitmasks are wrapped in a special structure,
-    // so when referencing them, we need to apply the wrapper.
-    let bitmask_workaround = match &expression.result_type {
-        ExpressionType::BitMask(_) => String::from(".bitmask_value"),
-        _ => String::from(""),
-    };
-
     // check for early returns, where no full type addressing is needed.
     match &symbol_ref.symbol {
         Symbol::Field(f) => {
             return format!(
-                "self.{}{}",
+                "self.{}",
                 type_generator.convert_field_name(&f.borrow().name),
-                &bitmask_workaround
             );
         }
         Symbol::Parameter(p) => {
             return format!(
-                "self.{}{}",
-                type_generator.convert_field_name(&p.borrow().name),
-                &bitmask_workaround
+                "self.{}",
+                type_generator.convert_field_name(&p.borrow().name)
             )
         }
         Symbol::Function(z_function) => {
@@ -337,9 +321,7 @@ fn generate_identifier_expression(
         Symbol::Choice(c) => type_generator.custom_type_to_rust_type(&c.borrow().name),
         Symbol::Union(u) => type_generator.custom_type_to_rust_type(&u.borrow().name),
         Symbol::Enum(e) => type_generator.custom_type_to_rust_type(&e.borrow().name),
-        Symbol::Bitmask(bitmask) => {
-            type_generator.custom_type_to_rust_type(&bitmask.borrow().name) + ".bitmask_value"
-        }
+        Symbol::Bitmask(bitmask) => type_generator.custom_type_to_rust_type(&bitmask.borrow().name),
         Symbol::Const(zconst) => type_generator.constant_type_to_rust_type(&zconst.borrow().name),
         _ => panic!("unsupported identifier type {:?}", expression.symbol),
     };

--- a/src/internal/generator/expression.rs
+++ b/src/internal/generator/expression.rs
@@ -1,7 +1,6 @@
 use crate::internal::ast::expression::{
     EvaluationState, Expression, ExpressionFlag, ExpressionType,
 };
-use crate::internal::compiler::fundamental_type::get_fundamental_type;
 use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
 use crate::internal::generator::types::{convert_to_enum_field_name, TypeGenerator};
 use crate::internal::parser::gen::zserioparser::{
@@ -181,24 +180,6 @@ fn generate_bracketed_expression(
         generate_expression(expression.operand1.as_ref().unwrap(), type_generator, scope),
         generate_expression(expression.operand2.as_ref().unwrap(), type_generator, scope),
     )
-}
-
-fn is_bitmask_expression(expression: &Expression, scope: &ModelScope) -> bool {
-    if let Some(expr_symbol) = &expression.symbol {
-        let fund_type = match &expr_symbol.symbol {
-            Symbol::Field(field) => get_fundamental_type(&field.borrow().field_type, scope),
-            Symbol::Parameter(param) => get_fundamental_type(&param.borrow().zserio_type, scope),
-            _ => return false,
-        };
-        if fund_type.fundamental_type.is_builtin {
-            return false;
-        }
-        return matches!(
-            scope.get_symbol(&fund_type.fundamental_type).symbol,
-            Symbol::Bitmask(_)
-        );
-    }
-    false
 }
 
 fn generate_dot_expression(

--- a/src/internal/generator/subtype.rs
+++ b/src/internal/generator/subtype.rs
@@ -17,7 +17,7 @@ pub fn generate_subtype(
     let rust_module_name = type_generator.to_rust_module_name(&subtype.name);
     let type_alias_scope = codegen_scope.new_type_alias(
         type_generator.to_rust_type_name(&subtype.name),
-        &type_generator.ztype_to_rust_type(&subtype.zserio_type),
+        type_generator.ztype_to_rust_type(&subtype.zserio_type),
     );
     type_alias_scope.vis("pub");
 

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -27,7 +27,7 @@ pub fn generate_struct_member_for_field(
         field_type = format!("Option<{}>", field_type.as_str());
     }
     let gen_field =
-        gen_struct.new_field(&type_generator.convert_field_name(&field.name), &field_type);
+        gen_struct.new_field(type_generator.convert_field_name(&field.name), &field_type);
     gen_field.vis("pub");
 }
 

--- a/src/internal/model.rs
+++ b/src/internal/model.rs
@@ -25,7 +25,7 @@ pub struct Model {
 
 impl Model {
     /// Loads a complete zserio model from a directory.
-    /// It iterates over a directoy, and parses all `*.zs` files,
+    /// It iterates over a directory, and parses all `*.zs` files,
     /// and loads them into a `Model` structure.
     pub fn from_filesystem(directory: &Path) -> Self {
         let mut packages = HashMap::new();
@@ -52,10 +52,11 @@ impl Model {
     }
 
     /// Evaluates a zserio model by
-    /// 1) instantiatng all templates.
+    /// 1) instantiating all templates.
     /// 2) perform a type resolution and ensure that all types
     ///    are correctly referenced.
     /// 3) evaluate all expressions.
+    ///
     /// Currently, this function will panic if there is an error
     /// during any of the above steps.
     pub fn evaluate(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
+//!
 //! [zserio](http://zserio.org/) serialization bindings for rust.
 //! `zserio` is a binary serialization language, similar to Protobuf. The key features are:
 //! - It features a rich schema.
 //! - Programming language agnostic.
 //! - Compact and easy to use.
 //! - Good and fast out-of the box compression.
+//!
 //! The syntax is similar to C/C++, which makes zserio code easy to read.
 //!
 //! Example:

--- a/tests/reference-module-lib/Cargo.toml
+++ b/tests/reference-module-lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitmask-enum = "2.2.4"
 bitreader =  "0.3.8"
 rust-bitwriter = "0.0.1"
 rust-zserio = { path = "../.." }

--- a/tests/reference-module-lib/src/lib.rs
+++ b/tests/reference-module-lib/src/lib.rs
@@ -45,6 +45,9 @@ pub mod reference_modules {
         pub mod index_operator;
         pub mod parameter_passing;
     }
+    pub mod parameter_passing_bitmask {
+        pub mod parameter_passing_bitmask;
+    }
     pub mod parameterized_array_length {
         pub mod parameterized_array_length;
     }
@@ -66,5 +69,8 @@ pub mod reference_modules {
     }
     pub mod user {
         pub mod testobject;
+    }
+    pub mod valueof_operator {
+        pub mod valueof_operator;
     }
 }

--- a/tests/reference-module-lib/src/lib.rs
+++ b/tests/reference-module-lib/src/lib.rs
@@ -70,7 +70,4 @@ pub mod reference_modules {
     pub mod user {
         pub mod testobject;
     }
-    pub mod valueof_operator {
-        pub mod valueof_operator;
-    }
 }

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -9,6 +9,7 @@ import reference_modules.type_lookup_test.ztype.*;
 import reference_modules.type_lookup_test.other_ztype.*;
 import reference_modules.parameter_passing.index_operator.*;
 import reference_modules.parameter_passing.parameter_passing.*;
+import reference_modules.parameter_passing_bitmask.parameter_passing_bitmask.*;
 import reference_modules.ambiguous_types.main.*;
 import reference_modules.ambiguous_types.other.*;
 import reference_modules.template_instantiation.template_instantiation.*;

--- a/tests/reference_modules/parameter_passing_bitmask/parameter_passing_bitmask.zs
+++ b/tests/reference_modules/parameter_passing_bitmask/parameter_passing_bitmask.zs
@@ -1,0 +1,25 @@
+package reference_modules.parameter_passing_bitmask.parameter_passing_bitmask;
+
+
+bitmask uint8 SomeBitMask
+{
+    HAS_A,
+    HAS_B = 0x04,
+    HAS_C,
+};
+
+// This is a simple test case to passing a bitmask as a parameter.
+struct ParameterPassingBitmask
+{
+    SomeBitMask someMask;
+
+    // Test passing of parameters to a single instance.
+    Item(someMask)  block;
+};
+
+struct Item(SomeBitMask someMask)
+{
+    // Add a conditional item, that depends on the parameter passed in the index.
+    // This ensures that during serialization / deserialization, the item is correctly passed.
+    uint8 conditionItem if isset(someMask, SomeBitMask.HAS_A);
+};

--- a/tests/round-trip-tests/src/bitmask_isset_test.rs
+++ b/tests/round-trip-tests/src/bitmask_isset_test.rs
@@ -1,6 +1,5 @@
 use reference_module_lib::reference_modules::bitmask_isset::bitmask_isset::{
-    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask, some_bit_mask::FLAG_A,
-    some_bit_mask::FLAG_B, some_bit_mask::FLAG_C,
+    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask,
 };
 
 use rust_zserio::ztype::ZserioPackableObject;
@@ -10,9 +9,7 @@ use rust_bitwriter::BitWriter;
 
 pub fn test_bitmask_isset_round_trip() {
     let mut test_struct = BitmaskTest::new();
-    test_struct.value = SomeBitMask {
-        bitmask_value: FLAG_A | FLAG_B,
-    };
+    test_struct.value = SomeBitMask::FlagA | SomeBitMask::FlagB;
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -31,9 +28,7 @@ pub fn test_bitmask_isset_round_trip() {
 
 pub fn test_bitmask_isset_operator() {
     let mut test_struct = BitmaskTest::new();
-    test_struct.value = SomeBitMask {
-        bitmask_value: FLAG_A | FLAG_B,
-    };
+    test_struct.value = SomeBitMask::FlagA | SomeBitMask::FlagB;
 
     // Ensure that the isset() operator works correctly.
     assert!(test_struct.has_a());
@@ -44,16 +39,14 @@ pub fn test_bitmask_isset_operator() {
     // Change the bitmask value. The value change should reflect
     // in the output of the functions that use the isset()
     // operator.
-    test_struct.value = SomeBitMask {
-        bitmask_value: FLAG_C,
-    };
+    test_struct.value = SomeBitMask::FlagC;
 
     assert!(!test_struct.has_a());
     assert!(!test_struct.has_b());
     assert!(test_struct.has_c());
     assert!(test_struct.has_a_or_c());
 
-    test_struct.value = SomeBitMask { bitmask_value: 0 };
+    test_struct.value = SomeBitMask::none();
     assert!(!test_struct.has_a());
     assert!(!test_struct.has_b());
     assert!(!test_struct.has_c());

--- a/tests/round-trip-tests/src/bitmask_test.rs
+++ b/tests/round-trip-tests/src/bitmask_test.rs
@@ -1,6 +1,5 @@
 use reference_module_lib::reference_modules::bitmask_test::bitmask_test::{
-    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask, some_bit_mask::HAS_A,
-    some_bit_mask::HAS_B,
+    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask,
 };
 
 use rust_zserio::ztype::ZserioPackableObject;
@@ -10,9 +9,7 @@ use rust_bitwriter::BitWriter;
 
 pub fn test_bitmasks() {
     let mut test_struct = BitmaskTest::new();
-    test_struct.selector = SomeBitMask {
-        bitmask_value: HAS_A | HAS_B,
-    };
+    test_struct.selector = SomeBitMask::HasA | SomeBitMask::HasB;
 
     test_struct.value_a = 123;
     test_struct.value_b = 456;

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -7,6 +7,7 @@ pub mod expr_numbits_test;
 pub mod integer_types_test;
 pub mod optional_values_test;
 pub mod packed_arrays_test;
+pub mod parameter_passing_bitmask_test;
 pub mod parameter_passing_test;
 pub mod parameterized_array_length_test;
 pub mod subtyped_dot_expression;
@@ -39,6 +40,7 @@ use crate::optional_values_test::{
     test_optional_arrays, test_optional_members, test_optional_values,
 };
 use crate::packed_arrays_test::test_packed_arrays;
+use crate::parameter_passing_bitmask_test::test_passing_bitmask_parameter;
 use crate::parameter_passing_test::{test_index_operator, test_parameter_passing};
 use crate::parameterized_array_length_test::test_parameterized_array_length;
 use crate::subtyped_dot_expression::test_subtyped_dot_expression;
@@ -54,6 +56,7 @@ fn main() {
     test_type_lookup();
     test_union_type();
     test_parameter_passing();
+    test_passing_bitmask_parameter();
     test_index_operator();
     test_ambiguous_types();
     test_type_casts();

--- a/tests/round-trip-tests/src/packed_arrays_test.rs
+++ b/tests/round-trip-tests/src/packed_arrays_test.rs
@@ -1,7 +1,7 @@
 use bitreader::BitReader;
 use reference_module_lib::reference_modules::packed_arrays::packed_arrays::{
-    bubble_tea_addons::BubbleTeaAddons, bubble_tea_size::BubbleTeaSize,
-    data_struct::DataStruct, packed_array_wrapper::PackedArrayWrapper,
+    bubble_tea_addons::BubbleTeaAddons, bubble_tea_size::BubbleTeaSize, data_struct::DataStruct,
+    packed_array_wrapper::PackedArrayWrapper,
 };
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::array_traits::packing_context_node::PackingContextNode;

--- a/tests/round-trip-tests/src/packed_arrays_test.rs
+++ b/tests/round-trip-tests/src/packed_arrays_test.rs
@@ -1,7 +1,7 @@
 use bitreader::BitReader;
 use reference_module_lib::reference_modules::packed_arrays::packed_arrays::{
-    bubble_tea_addons, bubble_tea_size::BubbleTeaSize, data_struct::DataStruct,
-    packed_array_wrapper::PackedArrayWrapper,
+    bubble_tea_addons::BubbleTeaAddons, bubble_tea_size::BubbleTeaSize,
+    data_struct::DataStruct, packed_array_wrapper::PackedArrayWrapper,
 };
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::array_traits::packing_context_node::PackingContextNode;
@@ -28,9 +28,9 @@ fn get_test_data() -> PackedArrayWrapper {
     test_struct.packed_array[1].size = BubbleTeaSize::ColdMedium;
     test_struct.packed_array[2].size = BubbleTeaSize::ColdLarge;
 
-    test_struct.packed_array[0].tea_addons.bitmask_value =
-        bubble_tea_addons::HAS_BLACK_SUGAR | bubble_tea_addons::HAS_ICE;
-    test_struct.packed_array[1].tea_addons.bitmask_value = bubble_tea_addons::HAS_CREAM_CHEESE;
+    test_struct.packed_array[0].tea_addons =
+        BubbleTeaAddons::HasBlackSugar | BubbleTeaAddons::HasIce;
+    test_struct.packed_array[1].tea_addons = BubbleTeaAddons::HasCreamCheese;
 
     test_struct.packed_array[2].bo_value_2 = true;
     test_struct.packed_array[2].i_16_value_3 = 453;

--- a/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
@@ -1,0 +1,46 @@
+use reference_module_lib::reference_modules::parameter_passing_bitmask::parameter_passing_bitmask::{
+    item::Item, some_bit_mask::SomeBitMask, parameter_passing_bitmask::ParameterPassingBitmask
+};
+
+use bitreader::BitReader;
+use rust_bitwriter::BitWriter;
+use rust_zserio::ztype::ZserioPackableObject;
+
+pub fn test_passing_bitmask_parameter() {
+    // Create a test structure, which uses parameter passing
+    let mut test_struct = ParameterPassingBitmask {
+        some_mask: SomeBitMask::HasA,
+        block: Item::new(),
+    };
+
+    // We will assign a random value to the optional field, then
+    // serialize and deserialize the data. If parameter passing
+    // works correctly, the conditional item should only be serialized
+    // if the condition is correct.
+    // the conditional item will only be serialized if the condition
+    // `isset(someMask, SomeBitMask.HAS_A)` is true.
+    test_struct.block.condition_item = 10;
+    let other_test_struct = serialize_and_deserialize(&test_struct);
+
+    // some_mask is set to `HasA`, as such the value should have been serialized/deserialized.
+    assert!(other_test_struct.block.condition_item == 10);
+
+    // do the same again, but change the parameter, so that the
+    // conditional item doesn't get serialized.
+    test_struct.some_mask = SomeBitMask::HasB | SomeBitMask::HasC;
+    // parameters still need to be updated manually
+    test_struct.block.some_mask = test_struct.some_mask;
+    let yet_another_test_struct = serialize_and_deserialize(&test_struct);
+    assert!(yet_another_test_struct.block.condition_item == 0);
+}
+
+fn serialize_and_deserialize(test_obj: &ParameterPassingBitmask) -> ParameterPassingBitmask {
+    let mut bitwriter = BitWriter::new();
+    test_obj.zserio_write(&mut bitwriter);
+    let serialized_bytes = bitwriter.data();
+
+    let mut other_test_struct = ParameterPassingBitmask::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct.zserio_read(&mut bitreader);
+    other_test_struct
+}


### PR DESCRIPTION
- previously, zserio bitmask types were generated as a struct with a field `bitmask_value`, wrapping the actual bitmask.
- this caused trouble when passing bitmask types as parameters.
- to resolve this, the bitmask types now use the `bitmask_enum` library (https://docs.rs/bitmask-enum/latest/bitmask_enum/).
- instead of a struct wrapping the bitmask, the new type will use enums, allowing for cleaner syntax.
- added a test to ensure parameter passing of bitmasks work.