### PR TITLE
Fix bitmask values (add support for `NONE = 0`, and fix missing bitmask expression value assignment)

### DIFF
--- a/src/internal/ast/zbitmask.rs
+++ b/src/internal/ast/zbitmask.rs
@@ -48,14 +48,19 @@ impl ZBitmaskType {
                     ExpressionType::Integer(v) => v as u64,
                     _ => panic!("only integer bitmask values are supported"),
                 };
-                if expr_bitmask_value < bitmask_value {
+                if expr_bitmask_value < bitmask_value && expr_bitmask_value != 0 {
                     panic!("expression redefines bitmask value");
                 }
+                bitmask_value = expr_bitmask_value;
             }
             value.value = bitmask_value;
 
             // Pick the next bit for the next bitmask value.
-            bitmask_value <<= 1;
+            if bitmask_value == 0 {
+                bitmask_value = 1;
+            } else {
+                bitmask_value <<= 1;
+            }
         }
         self.zserio_type.evaluate(scope);
     }

--- a/tests/reference_modules/bitmask_test/bitmask_test.zs
+++ b/tests/reference_modules/bitmask_test/bitmask_test.zs
@@ -13,3 +13,11 @@ struct BitmaskTest {
     int32 valueB if (selector & SomeBitMask.HAS_B) == SomeBitMask.HAS_B;
     int32 valueC if (selector & SomeBitMask.HAS_C) == SomeBitMask.HAS_C;
 };
+
+bitmask uint8 BitmaskWithZero
+{
+    NO_VALUE = 0,
+    VALUE_A,
+    VALUE_B = 0x04,
+    VALUE_C,
+};

--- a/tests/round-trip-tests/src/bitmask_test.rs
+++ b/tests/round-trip-tests/src/bitmask_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::bitmask_test::bitmask_test::{
-    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask,
+    bitmask_test::BitmaskTest, bitmask_with_zero::BitmaskWithZero, some_bit_mask::SomeBitMask,
 };
 
 use rust_zserio::ztype::ZserioPackableObject;
@@ -33,4 +33,12 @@ pub fn test_bitmasks() {
 
     // The following field should still be 0, because the condition is not used.
     assert!(other_test_struct.value_c == 0);
+}
+
+pub fn test_bitmask_values_with_zero() {
+    // test the assigned values of the bitmask.
+    assert!(BitmaskWithZero::NoValue == 0);
+    assert!(BitmaskWithZero::ValueA == 1);
+    assert!(BitmaskWithZero::ValueB == 4);
+    assert!(BitmaskWithZero::ValueC == 8);
 }

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -33,7 +33,7 @@ use rust_zserio::ztype::ZserioPackableObject;
 use crate::alignment_test::{test_alignment, test_alignment_roundtrip};
 use crate::ambiguous_types_test::test_ambiguous_types;
 use crate::bitmask_isset_test::{test_bitmask_isset_operator, test_bitmask_isset_round_trip};
-use crate::bitmask_test::test_bitmasks;
+use crate::bitmask_test::{test_bitmask_values_with_zero, test_bitmasks};
 use crate::constants_test::test_constants;
 use crate::expr_numbits_test::test_expr_numbits;
 use crate::integer_types_test::test_integer_types;
@@ -66,6 +66,7 @@ fn main() {
     test_optional_members();
     test_optional_arrays();
     test_bitmasks();
+    test_bitmask_values_with_zero();
     test_bitmask_isset_operator();
     test_bitmask_isset_round_trip();
     test_constants();

--- a/tests/round-trip-tests/src/valueof_operator_test.rs
+++ b/tests/round-trip-tests/src/valueof_operator_test.rs
@@ -16,7 +16,7 @@ pub fn test_valueof_operator() {
 
     // Change the bitmask, and assume the value is correctly deduced.
     zstruct.color = Color::Green | Color::Blue;
-    assert!(zstruct.get_value_of_color() == 6);
+    assert!(zstruct.get_value_of_color() == 12);
 
     zstruct.color = Color::none();
     assert!(zstruct.get_value_of_color() == 0);


### PR DESCRIPTION
- adds a testcase for bitmask values 0 (i.e. `NONE = 0`).
- adds a testcase to check that the bitmask expressions are correctly evaluated (e.g. `VALUE = 0x50`).
- corrected a buggy testcase, which ignored the bitmask expression.