### PR TITLE
Add support for offsets and offset arrays

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,6 +61,25 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "Debug integration tests 'compare-ref-impl-tests'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=compare-ref-impl-tests",
+                    "--package=compare-ref-impl-tests",
+                ],
+                "filter": {
+                    "name": "compare-ref-impl-tests",
+                    "kind": "bin",
+                },
+            },
+            "args": [
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "Debug unit tests in executable 'rust-zserio'",
             "cargo": {
                 "args": [
@@ -74,6 +93,14 @@
             },
             "args": [],
             "cwd": "${workspaceFolder}"
-        }
+        },
+        {
+            "name": "Launch Python 'compare-ref-impl-tests'",
+            "type": "python",
+            "request": "launch",
+            "program": "tests/compare-ref-impl-tests/python/main.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+          },
     ]
 }

--- a/src/internal/ast/expression.rs
+++ b/src/internal/ast/expression.rs
@@ -163,10 +163,9 @@ impl Expression {
         match &self.operand1 {
             Some(op1) => {
                 match &op1.result_type {
-                    ExpressionType::Compound => {
-                        // TODO
-                    }
-                    _ => panic!("todo"),
+                    ExpressionType::Compound => {}
+                    ExpressionType::Integer(_) => {} // for @index expressions in offset
+                    _ => panic!("unexpected array expression index type"),
                 }
             }
             _ => panic!("array element requires an operand to be set"),

--- a/src/internal/ast/field.rs
+++ b/src/internal/ast/field.rs
@@ -43,6 +43,9 @@ pub struct Field {
     /// (Optional) An expression, providing a default value for the field.
     pub initializer: Option<Rc<RefCell<Expression>>>,
 
+    /// (Optional) an expression
+    pub offset: Option<Rc<RefCell<Expression>>>,
+
     /// (Optional) A constraint which restricts the possible values that can be assigned.
     pub constraint: Option<Rc<RefCell<Expression>>>,
 

--- a/src/internal/generator.rs
+++ b/src/internal/generator.rs
@@ -6,6 +6,7 @@ pub mod encode;
 pub mod expression;
 pub mod file_generator;
 pub mod function;
+pub mod index_offsets;
 pub mod mod_file;
 pub mod model;
 pub mod new;

--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -125,7 +125,7 @@ pub fn instantiate_zserio_array(
         ),
         None => "None".to_owned(),
     };
-    function.line(format!("fixed_size: {},", array_length_str));
-    function.line(format!("is_packed: {},", is_packed));
+    function.line(format!("fixed_size: {array_length_str},"));
+    function.line(format!("is_packed: {is_packed},"));
     function.line("};");
 }

--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -125,7 +125,7 @@ pub fn instantiate_zserio_array(
     };
     function.line(format!("fixed_size: {},", array_length_str));
 
-    function.line(format!("is_aligned: {},", field.alignment != 0));
+    function.line(format!("is_aligned: {},", use_indexed_offset));
 
     function.line(format!("is_packed: {},", is_packed));
     function.line("};");

--- a/src/internal/generator/array.rs
+++ b/src/internal/generator/array.rs
@@ -97,6 +97,7 @@ pub fn instantiate_zserio_array(
     function: &mut Function,
     field: &Field,
     force_packed: bool,
+    is_packable: bool,
 ) {
     if field.array.is_none() {
         return;
@@ -104,7 +105,8 @@ pub fn instantiate_zserio_array(
     let native_type = get_fundamental_type(&field.field_type, scope);
     let fund_type = native_type.fundamental_type;
     let rust_type = type_generator.ztype_to_rust_type(field.field_type.as_ref());
-    let is_packed = field.array.as_ref().unwrap().is_packed || force_packed;
+    let field_array = field.array.as_ref().unwrap();
+    let is_packed = (field_array.is_packed || force_packed) && is_packable;
 
     // also initialize the array part
     function.line(format!(
@@ -116,7 +118,7 @@ pub fn instantiate_zserio_array(
         "array_trait: Box::new({}),",
         initialize_array_trait(scope, type_generator, fund_type.as_ref())
     ));
-    let array_length_str = match &field.array.as_ref().unwrap().array_length_expression {
+    let array_length_str = match &field_array.array_length_expression {
         Some(array_length_expression) => format!(
             "Some(({}) as usize)",
             generate_expression(&array_length_expression.borrow(), type_generator, scope)
@@ -124,9 +126,6 @@ pub fn instantiate_zserio_array(
         None => "None".to_owned(),
     };
     function.line(format!("fixed_size: {},", array_length_str));
-
-    function.line(format!("is_aligned: {},", use_indexed_offset));
-
     function.line(format!("is_packed: {},", is_packed));
     function.line("};");
 }

--- a/src/internal/generator/index_offsets.rs
+++ b/src/internal/generator/index_offsets.rs
@@ -1,0 +1,20 @@
+use crate::internal::ast::expression::Expression;
+use crate::internal::parser::gen::zserioparser::LBRACKET;
+
+/// Generates the expression that is used for indexed expressions.
+pub fn extract_indexed_offset_expression(expression: &Expression) -> Expression {
+    // for @index offset expressions, only generate the variable name, not the
+    // full array expression.
+    // For example:
+    // Do not generate
+    // offset_var[@index]
+    // but generate
+    // offset_var
+    // only.
+    if expression.expression_type == LBRACKET {
+        return *(expression.operand1.as_ref().unwrap().clone());
+    }
+    // if the offset expression does not contain an @index array expression, it can be generated
+    // normally.
+    expression.clone()
+}

--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -416,11 +416,20 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                 _ => panic!("unexpected field alignment type"),
             }
         }
+    
+        if let Some(offset_ctx) = ctx.fieldOffset() {
+            match ZserioParserVisitorCompat::visit_fieldOffset(self, &offset_ctx) {
+                ZserioTreeReturnType::Expression(expr) => {
+                    field.offset = Option::from(Rc::from(RefCell::from(*expr)));
+                }
+                _ => panic!("unexpected field alignment type"),
+            }
+        }
 
         if let Some(field_initializer_ctx) = ctx.fieldInitializer() {
             match ZserioParserVisitorCompat::visit_fieldInitializer(self, &field_initializer_ctx) {
                 ZserioTreeReturnType::Expression(expr) => {
-                    field.initializer = Option::from(Rc::from(RefCell::from(*expr)))
+                    field.initializer = Option::from(Rc::from(RefCell::from(*expr)));
                 }
                 _ => panic!("unexpected field initializer type"),
             }
@@ -432,7 +441,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                 &field_optional_clause_ctx,
             ) {
                 ZserioTreeReturnType::Expression(expr) => {
-                    field.optional_clause = Option::from(Rc::from(RefCell::from(*expr)))
+                    field.optional_clause = Option::from(Rc::from(RefCell::from(*expr)));
                 }
                 _ => panic!("unexpected field optional clause type"),
             }

--- a/src/ztype/alignment.rs
+++ b/src/ztype/alignment.rs
@@ -3,22 +3,19 @@ use rust_bitwriter::BitWriter;
 
 /// Aligns the bit reader to a bit boundary, e.g. alignment_bits == 8 would align to the next
 /// byte boundary.
-pub fn align_reader(reader: &mut BitReader, alignment_bits: u8) {
-    let u64_alignment_bits = alignment_bits as u64;
+pub fn align_reader(reader: &mut BitReader, u64_alignment_bits: u64) {
     let cur_alignment = reader.position() % u64_alignment_bits;
     let bits_to_skip = (u64_alignment_bits - cur_alignment) % u64_alignment_bits;
     reader.skip(bits_to_skip).expect("failed to align reader");
 }
 
-pub fn align_writer(writer: &mut BitWriter, alignment_bits: u8) {
-    let u64_alignment_bits = alignment_bits as u64;
+pub fn align_writer(writer: &mut BitWriter, u64_alignment_bits: u64) {
     let cur_alignment = writer.bit_count() % u64_alignment_bits;
     let bits_to_skip = (u64_alignment_bits - cur_alignment) % u64_alignment_bits;
     writer.skip(bits_to_skip).expect("failed to align writer");
 }
 
-pub fn align_bitsize(bit_pos: u64, alignment_bits: u8) -> u64 {
-    let u64_alignment_bits = alignment_bits as u64;
+pub fn align_bitsize(bit_pos: u64, u64_alignment_bits: u64) -> u64 {
     let cur_alignment = bit_pos % u64_alignment_bits;
     (u64_alignment_bits - cur_alignment) % u64_alignment_bits
 }

--- a/src/ztype/array.rs
+++ b/src/ztype/array.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 use crate::ztype::array_traits::array_trait::ArrayTrait;
 use crate::ztype::read_varsize;
-use crate::ztype::varuint_encode::write_varsize;
 use crate::ztype::varsize_bitsize;
+use crate::ztype::varuint_encode::write_varsize;
 use bitreader::BitReader;
 use num::traits::Unsigned;
 use rust_bitwriter::BitWriter;

--- a/src/ztype/array.rs
+++ b/src/ztype/array.rs
@@ -2,19 +2,33 @@ use crate::error::Result;
 use crate::ztype::array_traits::array_trait::ArrayTrait;
 use crate::ztype::read_varsize;
 use crate::ztype::varuint_encode::write_varsize;
-use crate::ztype::{align_to, varsize_bitsize};
+use crate::ztype::varsize_bitsize;
 use bitreader::BitReader;
+use num::traits::Unsigned;
 use rust_bitwriter::BitWriter;
+
+use crate::ztype::alignment::{align_bitsize, align_reader, align_writer};
 
 pub struct Array<T> {
     pub array_trait: Box<dyn ArrayTrait<T>>,
     pub is_packed: bool,
     pub fixed_size: Option<usize>,
-    pub is_aligned: bool,
 }
 
+pub trait OffsetTrait: Unsigned + Copy + std::convert::Into<u64> {}
+
+impl OffsetTrait for u8 {}
+impl OffsetTrait for u16 {}
+impl OffsetTrait for u32 {}
+impl OffsetTrait for u64 {}
+
 impl<T> Array<T> {
-    pub fn zserio_write(&mut self, writer: &mut BitWriter, data: &Vec<T>) -> Result<()> {
+    pub fn zserio_write<U: OffsetTrait>(
+        &mut self,
+        writer: &mut BitWriter,
+        data: &Vec<T>,
+        index_offsets: Option<&Vec<U>>,
+    ) -> Result<()> {
         if let Some(expected_array_len) = self.fixed_size {
             // for fixed-size arrays, the provided length must match
             assert_eq!(expected_array_len, data.len());
@@ -37,18 +51,14 @@ impl<T> Array<T> {
             }
 
             // Actually write the data.
-            for element in data.iter() {
-                if self.is_aligned {
-                    let _ = writer.align(1);
-                }
+            for (index, element) in data.iter().enumerate() {
+                align_array_element_writer(writer, index, index_offsets);
                 self.array_trait
                     .write_packed(&mut packing_context_node, writer, element)?;
             }
         } else {
-            for element in data.iter() {
-                if self.is_aligned {
-                    let _ = writer.align(1);
-                }
+            for (index, element) in data.iter().enumerate() {
+                align_array_element_writer(writer, index, index_offsets);
                 self.array_trait.write(writer, element)?;
             }
         }
@@ -62,15 +72,18 @@ impl<T> Array<T> {
         }
     }
 
-    pub fn zserio_read(&mut self, reader: &mut BitReader, data: &mut [T]) -> Result<()> {
+    pub fn zserio_read<U: OffsetTrait>(
+        &mut self,
+        reader: &mut BitReader,
+        data: &mut [T],
+        index_offsets: Option<&Vec<U>>,
+    ) -> Result<()> {
         if !data.is_empty() {
             if self.is_packed {
                 // Create the packing context, and all child-contexts
                 let mut packing_context_node = self.array_trait.create_context();
                 for (index, data_item) in data.iter_mut().enumerate() {
-                    if self.is_aligned {
-                        reader.align(1)?;
-                    }
+                    align_array_element_reader(reader, index, index_offsets);
                     self.array_trait.read_packed(
                         &mut packing_context_node,
                         reader,
@@ -80,9 +93,7 @@ impl<T> Array<T> {
                 }
             } else {
                 for (index, data_item) in data.iter_mut().enumerate() {
-                    if self.is_aligned {
-                        reader.align(1)?;
-                    }
+                    align_array_element_reader(reader, index, index_offsets);
                     self.array_trait.read(reader, data_item, index)?;
                 }
             }
@@ -90,7 +101,12 @@ impl<T> Array<T> {
         Ok(())
     }
 
-    pub fn zserio_bitsize(&mut self, data: &Vec<T>, bit_position: u64) -> Result<u64> {
+    pub fn zserio_bitsize<U: OffsetTrait>(
+        &mut self,
+        data: &Vec<T>,
+        index_offsets: Option<&Vec<U>>,
+        bit_position: u64,
+    ) -> Result<u64> {
         let mut end_position = bit_position;
         if self.fixed_size.is_none() {
             end_position += varsize_bitsize(data.len() as u32)? as u64;
@@ -106,38 +122,28 @@ impl<T> Array<T> {
                         .init_context(&mut packing_context_node, element)?;
                 }
 
-                for data_item in data {
-                    if self.is_aligned {
-                        end_position = align_to(8, end_position);
-                    }
+                for (index, element) in data.iter().enumerate() {
+                    end_position = align_array_element_bitsize(end_position, index, index_offsets);
                     end_position += self.array_trait.bitsize_of_packed(
                         &mut packing_context_node,
                         end_position,
-                        data_item,
+                        element,
                     )?;
                 }
             } else {
                 // Array is not packed
-                if self.array_trait.is_bitsizeof_constant() {
+                if self.array_trait.is_bitsizeof_constant() && index_offsets.is_none() {
                     // Since the bitsize is anyway constant, just pass the first element
                     let element_size = self.array_trait.bitsize_of(end_position, &data[0])?;
-                    if self.is_aligned {
-                        // make sure the first element is aligned
-                        end_position = align_to(8, end_position);
-
-                        // count all array elements alignment positions
-                        end_position += (data.len() - 1) as u64 * align_to(8, element_size);
-                    }
 
                     // count the actual payload
                     end_position += data.len() as u64 * element_size;
                 } else {
                     // the bitsize of each array element may differ, as such, each element need to be
                     // added individually.
-                    for element in data {
-                        if self.is_aligned {
-                            end_position = align_to(8, end_position);
-                        }
+                    for (index, element) in data.iter().enumerate() {
+                        end_position =
+                            align_array_element_bitsize(end_position, index, index_offsets);
                         end_position += self.array_trait.bitsize_of(end_position, element)?;
                     }
                 }
@@ -146,7 +152,12 @@ impl<T> Array<T> {
         Ok(end_position - bit_position)
     }
 
-    pub fn zserio_bitsize_packed(&mut self, data: &Vec<T>, bit_position: u64) -> Result<u64> {
+    pub fn zserio_bitsize_packed<U: OffsetTrait>(
+        &mut self,
+        data: &Vec<T>,
+        index_offsets: Option<&Vec<U>>,
+        bit_position: u64,
+    ) -> Result<u64> {
         let mut end_position = bit_position;
         if self.fixed_size.is_none() {
             end_position += varsize_bitsize(data.len() as u32)? as u64;
@@ -159,10 +170,8 @@ impl<T> Array<T> {
                     .init_context(&mut packing_context_node, element)?;
             }
 
-            for element in data {
-                if self.is_aligned {
-                    end_position = align_to(8, end_position);
-                }
+            for (index, element) in data.iter().enumerate() {
+                end_position = align_array_element_bitsize(end_position, index, index_offsets);
                 end_position += self.array_trait.bitsize_of_packed(
                     &mut packing_context_node,
                     end_position,
@@ -172,4 +181,38 @@ impl<T> Array<T> {
         }
         Ok(end_position - bit_position)
     }
+}
+
+fn align_array_element_writer<T: OffsetTrait>(
+    writer: &mut BitWriter,
+    _index: usize,
+    index_offsets: Option<&Vec<T>>,
+) {
+    // A small helper function to byte-align each array element, if desired, during writing.
+    if index_offsets.is_some() {
+        align_writer(writer, 8);
+    }
+}
+fn align_array_element_reader<T: OffsetTrait>(
+    reader: &mut BitReader,
+    _index: usize,
+    index_offsets: Option<&Vec<T>>,
+) {
+    // A small helper function to byte-align each array element, if desired, during reading.
+    if index_offsets.is_some() {
+        align_reader(reader, 8);
+    }
+}
+
+fn align_array_element_bitsize<T: OffsetTrait>(
+    bit_position: u64,
+    _index: usize,
+    index_offsets: Option<&Vec<T>>,
+) -> u64 {
+    // A small helper function to byte-align each array element, if desired, during bitsize calculation.
+    let mut end_position = bit_position;
+    if index_offsets.is_some() {
+        end_position += align_bitsize(end_position, 8);
+    }
+    end_position
 }

--- a/src/ztype/array_traits/delta_context.rs
+++ b/src/ztype/array_traits/delta_context.rs
@@ -125,14 +125,14 @@ impl DeltaContext {
         if delta_bit_size > 0 {
             delta_bit_size += 1;
         }
-        let packed_bit_size_with_decriptor = 1
+        let packed_bit_size_with_descriptor = 1
             + MAX_BIT_NUMBER_BITS as u64
             + self.first_element_size
             + (self.num_elements - 1) * delta_bit_size;
 
         let unpacked_bit_size_with_descriptor = 1 + self.unpacked_size;
 
-        if packed_bit_size_with_decriptor >= unpacked_bit_size_with_descriptor {
+        if packed_bit_size_with_descriptor >= unpacked_bit_size_with_descriptor {
             self.is_packed = false;
         }
     }

--- a/tests/compare-ref-impl-tests/python/generate_artifacts.py
+++ b/tests/compare-ref-impl-tests/python/generate_artifacts.py
@@ -7,16 +7,27 @@ import zserio
 
 
 class ZserioPackableObject(Protocol):
+    @staticmethod
+    def create_packing_context(
+        zserio_context_node: zserio.array.PackingContextNode,
+    ) -> None:
+        ...
+
+    def init_packing_context(
+        self, zserio_context_node: zserio.array.PackingContextNode
+    ) -> None:
+        ...
+
     def bitsizeof(self, bitposition: int = 0) -> int:
-        pass
+        ...
 
     def bitsizeof_packed(
         self, zserio_context_node: zserio.array.PackingContextNode, bitposition: int = 0
     ) -> int:
-        pass
+        ...
 
     def write(self, zserio_writer: zserio.BitStreamWriter) -> None:
-        pass
+        ...
 
 
 def get_test_artifacts_dir() -> Path:
@@ -40,6 +51,8 @@ def generate_artifacts(name: str, zserio_object: ZserioPackableObject) -> None:
     bitsize = zserio_object.bitsizeof()
 
     packing_context_node = zserio.array.PackingContextNode()
+    type(zserio_object).create_packing_context(packing_context_node)
+    zserio_object.init_packing_context(packing_context_node)
     bitsize_packed = zserio_object.bitsizeof_packed(packing_context_node)
 
     json_attributes = {
@@ -47,5 +60,7 @@ def generate_artifacts(name: str, zserio_object: ZserioPackableObject) -> None:
         "bitsize_packed": bitsize_packed,
     }
 
-    with open(get_test_artifacts_dir() / f"{name}_stats.json", "w") as file_handle:
+    with open(
+        file=get_test_artifacts_dir() / f"{name}_stats.json", mode="w", encoding="utf-8"
+    ) as file_handle:
         json.dump(json_attributes, file_handle)

--- a/tests/compare-ref-impl-tests/python/main.py
+++ b/tests/compare-ref-impl-tests/python/main.py
@@ -1,8 +1,10 @@
 from packed_arrays_test import test_packed_arrays
+from offsets_test import test_offsets
 
 
 def run_all_tests() -> None:
     test_packed_arrays()
+    test_offsets()
 
 
 if __name__ == "__main__":

--- a/tests/compare-ref-impl-tests/python/offsets_test.py
+++ b/tests/compare-ref-impl-tests/python/offsets_test.py
@@ -1,0 +1,21 @@
+from generate_artifacts import generate_artifacts
+from pygen.reference_modules.offsets.offsets.offsets import (
+    Offsets,
+)
+
+
+def test_offsets() -> None:
+    testdata = Offsets(
+        u32_offset_=9,
+        vi32_array_=[22, 56, 635],
+        vi16_offset_array_=[11, 23, 42, 744],
+        u32_array_offset_=[33, 35, 37, 39],
+        vi64_index_offset_array_=[100, 200, 300, 400],
+        u8_check_=241,
+        u16_final_check_=14,
+        has_flag_=False,
+        u16_offset_=233,
+        u32_value_=14,
+        u16_yet_final_check_=42,
+    )
+    generate_artifacts(__name__, testdata)

--- a/tests/compare-ref-impl-tests/rust/src/deserialize_artifacts.rs
+++ b/tests/compare-ref-impl-tests/rust/src/deserialize_artifacts.rs
@@ -13,7 +13,7 @@ pub fn get_test_directory() -> PathBuf {
     path.join("..").join("artifacts")
 }
 
-/// Reads a zserio-enocoded object a binary file generated with Python, and ensures
+/// Reads a zserio-encoded object a binary file generated with Python, and ensures
 /// 1) That the file encoded with the python lib can be read,
 /// 2) That the object is binary identical to the Python code after serializing it again in rust,
 /// 3) Ensures the bit positions and bit counts are identical.
@@ -36,7 +36,7 @@ pub fn read_from_python_and_compare(
     assert_eq!(
         bitwriter.data(),
         &*data_bytes,
-        "binary data is diffferent to the Python reference implementation"
+        "binary data is different to the Python reference implementation"
     );
 
     compare_bitlength_calculations_with_python_reference(name, zserio_object);
@@ -76,6 +76,7 @@ pub fn compare_bitlength_calculations_with_python_reference<T: ZserioPackableObj
     // Calculate the packed bitsize
     let mut packing_context = PackingContextNode::new();
     T::zserio_create_packing_context(&mut packing_context);
+    zserio_object.zserio_init_packing_context(&mut packing_context);
     let actual_packed_bitsize = zserio_object
         .zserio_bitsize_packed(&mut packing_context, 0)
         .unwrap();

--- a/tests/compare-ref-impl-tests/rust/src/main.rs
+++ b/tests/compare-ref-impl-tests/rust/src/main.rs
@@ -1,7 +1,10 @@
 pub mod deserialize_artifacts;
+pub mod offsets_test;
 pub mod packed_arrays_test;
-use crate::packed_arrays_test::reference_implementation_test;
+use crate::offsets_test::offsets_test;
+use crate::packed_arrays_test::packed_arrays_test;
 
 fn main() {
-    reference_implementation_test();
+    offsets_test();
+    packed_arrays_test();
 }

--- a/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
+++ b/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
@@ -1,0 +1,9 @@
+use reference_module_lib::reference_modules::offsets::offsets::offsets::Offsets;
+
+use crate::deserialize_artifacts::read_from_python_and_compare;
+use rust_zserio::ztype::ZserioPackableObject;
+
+pub fn offsets_test() {
+    let mut test_obj = Offsets::new();
+    read_from_python_and_compare("offsets_test", &mut test_obj);
+}

--- a/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
+++ b/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
@@ -5,5 +5,6 @@ use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn offsets_test() {
     let mut test_obj = Offsets::new();
-    read_from_python_and_compare("offsets_test", &mut test_obj);
+    read_from_python_and_compare("offsets_test", &mut test_obj)
+        .expect("can not compare with python");
 }

--- a/tests/compare-ref-impl-tests/rust/src/packed_arrays_test.rs
+++ b/tests/compare-ref-impl-tests/rust/src/packed_arrays_test.rs
@@ -3,7 +3,7 @@ use reference_module_lib::reference_modules::packed_arrays::packed_arrays::packe
 use crate::deserialize_artifacts::read_from_python_and_compare;
 use rust_zserio::ztype::ZserioPackableObject;
 
-pub fn reference_implementation_test() {
+pub fn packed_arrays_test() {
     let mut test_obj = PackedArrayWrapper::new();
     read_from_python_and_compare("packed_arrays_test", &mut test_obj)
         .expect("can not compare with python");

--- a/tests/reference-module-lib/src/lib.rs
+++ b/tests/reference-module-lib/src/lib.rs
@@ -32,6 +32,9 @@ pub mod reference_modules {
     pub mod integer_types {
         pub mod integer_types;
     }
+    pub mod offsets {
+        pub mod offsets;
+    }
     pub mod optional_array {
         pub mod optional_array;
     }

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -14,6 +14,7 @@ import reference_modules.ambiguous_types.main.*;
 import reference_modules.ambiguous_types.other.*;
 import reference_modules.template_instantiation.template_instantiation.*;
 import reference_modules.type_casts.type_casts.*;
+import reference_modules.offsets.offsets.*;
 import reference_modules.optional_values.optional_values.*;
 import reference_modules.bitmask_test.bitmask_test.*;
 import reference_modules.bitmask_isset.bitmask_isset.*;

--- a/tests/reference_modules/offsets/offsets.zs
+++ b/tests/reference_modules/offsets/offsets.zs
@@ -1,0 +1,28 @@
+package reference_modules.offsets.offsets;
+
+struct Offsets {
+    uint32 u32Offset;
+
+    varint32 vi32Array[];
+
+u32Offset:
+    varint16 vi16OffsetArray[];
+
+    uint32 u32ArrayOffset[];
+
+u32ArrayOffset[@index]:
+    varint64 vi64IndexOffsetArray[];
+
+    uint8 u8Check;
+
+u8Check:
+    uint16 u16FinalCheck;
+
+    bool hasFlag;
+    uint16 u16Offset;
+u16Offset:
+    uint32 u32Value if hasFlag;
+
+    uint16 u16YetFinalCheck;
+
+};

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -6,6 +6,7 @@ pub mod constants_test;
 pub mod debug_trait_test;
 pub mod expr_numbits_test;
 pub mod integer_types_test;
+pub mod offsets_test;
 pub mod optional_values_test;
 pub mod packed_arrays_test;
 pub mod parameter_passing_bitmask_test;
@@ -40,6 +41,7 @@ use crate::constants_test::test_constants;
 use crate::debug_trait_test::test_debug_trait;
 use crate::expr_numbits_test::test_expr_numbits;
 use crate::integer_types_test::test_integer_types;
+use crate::offsets_test::test_offsets;
 use crate::optional_values_test::{
     test_optional_arrays, test_optional_members, test_optional_values,
 };
@@ -82,6 +84,7 @@ fn main() {
     test_expr_numbits();
     test_valueof_operator();
     test_debug_trait();
+    test_offsets();
 }
 
 fn test_structure() -> Result<()> {

--- a/tests/round-trip-tests/src/offsets_test.rs
+++ b/tests/round-trip-tests/src/offsets_test.rs
@@ -1,0 +1,54 @@
+use bitreader::BitReader;
+use reference_module_lib::reference_modules::offsets::offsets::offsets::Offsets;
+use rust_bitwriter::BitWriter;
+
+use rust_zserio::ztype::ZserioPackableObject;
+
+pub fn test_offsets() {
+    let mut test_struct = Offsets::new();
+
+    test_struct.u_32_offset = 1;
+    test_struct.vi_32_array = vec![10, 11, 13];
+    test_struct.vi_16_offset_array = vec![1, 3, 2, 7, -12];
+    test_struct.u_32_array_offset = vec![1, 3, 2, 4, 2];
+    test_struct.vi_64_index_offset_array = vec![100, 102, -2435425, -32543, 1510001];
+    test_struct.u_8_check = 127;
+    test_struct.u_16_final_check = 5523;
+    test_struct.has_flag = false;
+    test_struct.u_16_offset = 4;
+    test_struct.u_32_value = 242; // this value should not be stored, because it depends on `has_flag`.
+    test_struct.u_16_yet_final_check = 42;
+
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    test_struct.zserio_write(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_test_struct = Offsets::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct.zserio_read(&mut bitreader);
+
+    // expect them to be identical.
+    test_struct.u_32_value = 0;
+    assert!(test_struct == other_test_struct);
+
+    // try again with the optional field enabled.
+    test_struct.u_32_value = 5252;
+    test_struct.has_flag = true;
+
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    test_struct.zserio_write(&mut bitwriter);
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_test_struct = Offsets::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct.zserio_read(&mut bitreader);
+
+    // expect them to be identical.
+    assert!(test_struct == other_test_struct);
+}

--- a/tests/round-trip-tests/src/offsets_test.rs
+++ b/tests/round-trip-tests/src/offsets_test.rs
@@ -21,14 +21,18 @@ pub fn test_offsets() {
 
     // serialize
     let mut bitwriter = BitWriter::new();
-    test_struct.zserio_write(&mut bitwriter);
+    test_struct
+        .zserio_write(&mut bitwriter)
+        .expect("can not write zserio data");
     bitwriter.close().expect("failed to close bit stream");
     let serialized_bytes = bitwriter.data();
 
     // deserialize
     let mut other_test_struct = Offsets::new();
     let mut bitreader = BitReader::new(serialized_bytes);
-    other_test_struct.zserio_read(&mut bitreader);
+    other_test_struct
+        .zserio_read(&mut bitreader)
+        .expect("can read write zserio data");
 
     // expect them to be identical.
     test_struct.u_32_value = 0;
@@ -40,14 +44,18 @@ pub fn test_offsets() {
 
     // serialize
     let mut bitwriter = BitWriter::new();
-    test_struct.zserio_write(&mut bitwriter);
+    test_struct
+        .zserio_write(&mut bitwriter)
+        .expect("can not write zserio data");
     bitwriter.close().expect("failed to close bit stream");
     let serialized_bytes = bitwriter.data();
 
     // deserialize
     let mut other_test_struct = Offsets::new();
     let mut bitreader = BitReader::new(serialized_bytes);
-    other_test_struct.zserio_read(&mut bitreader);
+    other_test_struct
+        .zserio_read(&mut bitreader)
+        .expect("can not read zserio data");
 
     // expect them to be identical.
     assert!(test_struct == other_test_struct);


### PR DESCRIPTION
- The old code did not support indexed offsets. It would apply indexed offsets if the array field is aligned. This is not correct:
- an aligned field only is aligned once before the array blob is stored.
- an indexed offset aligns every array element (including the first one).


The support for offsets and indexed offsets was added as follows:
- adds support for parsing the offset expression.
- add support to generate the offset value passing during array
  encoding/decoding.
- update the logic on which arrays are packed / nonpacked: fields
  that specify the offset values are not allowed to be packed, and
  have to be forced to not use packing. For this reason, the
  algorithm that decides of packing is used or not was improved, and
  now has a clear priority:
1) If a type is an offset type, it will never be packed. If not, (2).
2) If the type is an array, it can be packed, if requested (or enforced).
3) If the type is not an array but a marshabale type, packing can be
   used, if requested (or enforced).
4) If the type is not a marshable type, but a integer type, packing can
   be used.
5) in all other cases, packing cannot be used, even if enforced (e.g.
   by putting this type into a struct, and that struct into an array,
   and pack this array.
