### PR TITLE
Fix imports in bin crate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
-use crate::internal::generator::model::generate_model;
-use crate::internal::model::Model;
 use clap::Parser;
+use rust_zserio::internal::generator::model::generate_model;
+use rust_zserio::internal::model::Model;
 use std::path::Path;
-pub mod internal;
-pub mod ztype;
 
 /// zserio generator for rust.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Importing ztype from both src/main.rs and src/lib.rs means that what it considers to be its crate can be either the binary or library crate, which results in very inconsistent behavior for `use crate::xyz` statements. In particular I kept getting errors for `crate::error` not existing from the compiler, even though the language server could see the crate without issues.

To clean this up I have removed all `mod` statements from the binary crate, and made it import the library crate.
