### PR TITLE
Improve error message for invalid enum values

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum ZserioError {
     #[error("IO error")]
     IoError(#[from] io::Error),
     #[error("data error: {0}")]
-    DataError(&'static str),
+    DataError(String),
 }
 
 impl From<bitreader::BitReaderError> for ZserioError {

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -76,7 +76,7 @@ pub fn generate_enum(
     }
 
     from_int_fn
-        .line(r#"_ => Err(rust_zserio::ZserioError::DataError("unexpected value for enum")),"#);
+        .line(format!("_ => Err(rust_zserio::ZserioError::DataError(format!(\"unexpected value for {}: {{}}\", v))),", rust_type_name));
 
     from_int_fn.line("}");
 

--- a/src/ztype/extern_type.rs
+++ b/src/ztype/extern_type.rs
@@ -43,10 +43,9 @@ pub fn write_extern_type(bit_writer: &mut BitWriter, extern_type: &ExternType) -
         &extern_type.data_blob[0..num_of_full_bytes].to_vec(),
     )?;
     if remaining_bits != 0 {
-        let mut last_byte = *extern_type
-            .data_blob
-            .last()
-            .ok_or(ZserioError::DataError("last byte for extern is missing"))?;
+        let mut last_byte = *extern_type.data_blob.last().ok_or(ZserioError::DataError(
+            "last byte for extern is missing".into(),
+        ))?;
         let bit_shift = 8 - remaining_bits;
         last_byte >>= bit_shift;
 

--- a/src/ztype/float_decode.rs
+++ b/src/ztype/float_decode.rs
@@ -6,12 +6,16 @@ use half::f16;
 
 pub fn read_float64(reader: &mut BitReader) -> Result<f64> {
     Ok(f64::from_be_bytes(read_bytes(reader, 8)?.try_into().or(
-        Err(ZserioError::DataError("can not convert bytes to float64")),
+        Err(ZserioError::DataError(
+            "can not convert bytes to float64".into(),
+        )),
     )?))
 }
 pub fn read_float32(reader: &mut BitReader) -> Result<f32> {
     Ok(f32::from_be_bytes(read_bytes(reader, 4)?.try_into().or(
-        Err(ZserioError::DataError("can not convert bytes to float32")),
+        Err(ZserioError::DataError(
+            "can not convert bytes to float32".into(),
+        )),
     )?))
 }
 pub fn read_float16(reader: &mut BitReader) -> Result<f32> {
@@ -19,7 +23,7 @@ pub fn read_float16(reader: &mut BitReader) -> Result<f32> {
         read_bytes(reader, 2)?
             .try_into()
             .or(Err(ZserioError::DataError(
-                "can not convert bytes to float16",
+                "can not convert bytes to float16".into(),
             )))?,
     )
     .to_f32())

--- a/src/ztype/varint_bitsize.rs
+++ b/src/ztype/varint_bitsize.rs
@@ -31,7 +31,7 @@ pub fn signed_bitsize(mut v: i64, max_bytes: u8) -> Result<u8> {
         bytes += 1;
         if bytes > max_bytes {
             return Err(ZserioError::DataError(
-                "too many bytes in signed bitsize value",
+                "too many bytes in signed bitsize value".into(),
             ));
         }
 

--- a/src/ztype/varuint_bitsize.rs
+++ b/src/ztype/varuint_bitsize.rs
@@ -31,7 +31,7 @@ pub fn unsigned_bitsize(v: u64, max_bytes: u8) -> Result<u8> {
         bytes += 1;
         if bytes > max_bytes {
             return Err(ZserioError::DataError(
-                "too many bytes in unsigned bitsize value",
+                "too many bytes in unsigned bitsize value".into(),
             ));
         }
 


### PR DESCRIPTION
Instead of printing `unexpected value for enum` we now generate `unexpected value for MyType: 123`.
