### PR TITLE
fix passing of parameters during template type instantiation

### DIFF
--- a/src/internal/ast/expression.rs
+++ b/src/internal/ast/expression.rs
@@ -11,6 +11,7 @@ use crate::internal::parser::gen::zserioparser::{
     LOGICAL_OR, LPAREN, LSHIFT, LT, MINUS, MODULO, MULTIPLY, NE, NUMBITS, OR, PLUS, QUESTIONMARK,
     RPAREN, RSHIFT, TILDE, VALUEOF, XOR,
 };
+use crate::ztype::numbits;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::string::String;
@@ -328,8 +329,7 @@ impl Expression {
         match &self.operand1 {
             Some(op1) => match op1.result_type {
                 ExpressionType::Integer(value) => {
-                    self.result_type =
-                        ExpressionType::Integer(32 - i32::leading_zeros(value) as i32);
+                    self.result_type = ExpressionType::Integer(numbits(value) as i32);
                     self.fully_resolved = op1.fully_resolved;
                     self.native_type = Some(TypeReference::new_native_type("varsize"));
                 }
@@ -337,7 +337,7 @@ impl Expression {
                     panic!("numbits operator can only be applied to integer expressions")
                 }
             },
-            _ => panic!("numbits operator expression requries one operator"),
+            _ => panic!("numbits operator expression requires one operator"),
         }
     }
 

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -351,6 +351,8 @@ pub fn instantiate_field(
     // TEMPLATE_TYPE field;
     if instantiated_types.contains_key(&field.field_type.name) {
         new_field.field_type = Box::from(instantiated_types[&field.field_type.name].clone());
+        // copy the parameters, if set
+        new_field.field_type.type_arguments = field.field_type.type_arguments.clone();
     }
     new_field
 }

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -1,3 +1,4 @@
+use crate::internal::ast::expression::Expression;
 use crate::internal::ast::field::Field;
 use crate::internal::ast::package::ZPackage;
 use crate::internal::ast::parameter::Parameter;
@@ -41,6 +42,7 @@ pub fn instantiate_type(
                 scope,
                 &s.as_ref().borrow(),
                 &zserio_type.template_arguments,
+                &zserio_type.type_arguments,
                 &new_type_name,
             );
         }
@@ -50,6 +52,7 @@ pub fn instantiate_type(
                 scope,
                 &c.as_ref().borrow(),
                 &zserio_type.template_arguments,
+                &zserio_type.type_arguments,
                 &new_type_name,
             );
         }
@@ -70,6 +73,7 @@ fn instantiate_struct(
     scope: &mut ModelScope,
     z_struct: &ZStruct,
     template_arguments: &[TypeReference],
+    type_arguments: &[Rc<RefCell<Expression>>],
     instantiated_name: &String,
 ) -> TypeReference {
     assert!(!z_struct.template_parameters.is_empty());
@@ -81,7 +85,7 @@ fn instantiate_struct(
         name: instantiated_name.clone(),
         bits: 0,
         template_arguments: vec![],
-        type_arguments: vec![],
+        type_arguments: type_arguments.to_owned(),
         length_expression: None,
     };
 
@@ -181,6 +185,7 @@ fn instantiate_choice(
     scope: &mut ModelScope,
     z_choice: &ZChoice,
     template_arguments: &[TypeReference],
+    type_arguments: &[Rc<RefCell<Expression>>],
     instantiated_name: &String,
 ) -> TypeReference {
     assert!(!z_choice.template_parameters.is_empty());
@@ -192,7 +197,7 @@ fn instantiate_choice(
         name: instantiated_name.clone(),
         bits: 0,
         template_arguments: vec![],
-        type_arguments: vec![],
+        type_arguments: type_arguments.to_owned(),
         length_expression: None,
     };
 

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -352,7 +352,10 @@ pub fn instantiate_field(
     if instantiated_types.contains_key(&field.field_type.name) {
         new_field.field_type = Box::from(instantiated_types[&field.field_type.name].clone());
         // copy the parameters, if set
-        new_field.field_type.type_arguments = field.field_type.type_arguments.clone();
+        new_field
+            .field_type
+            .type_arguments
+            .clone_from(&field.field_type.type_arguments);
     }
     new_field
 }

--- a/src/ztype.rs
+++ b/src/ztype.rs
@@ -62,7 +62,7 @@ pub use self::traits::ZserioPackableObject;
 pub use self::bytes_type::{bitsize_of_bytes, read_bytes_type, write_bytes_type, BytesType};
 pub use self::extern_type::{bitsize_of_extern, read_extern_type, write_extern_type, ExternType};
 
-pub use self::numbits::numbits;
+pub use self::numbits::{bit_length, numbits};
 
 pub use self::alignment::{align_bitsize, align_reader, align_writer};
 pub mod bits_decode;

--- a/src/ztype/array_traits/delta_context.rs
+++ b/src/ztype/array_traits/delta_context.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::ztype::array_traits::array_trait::ArrayTrait;
 use crate::ztype::bits_decode::read_signed_bits;
-use crate::ztype::{self, numbits, read_unsigned_bits};
+use crate::ztype::{self, bit_length, read_unsigned_bits};
 
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
@@ -59,7 +59,7 @@ impl DeltaContext {
         } else if self.max_bit_number <= MAX_BIT_NUMBER_LIMIT {
             self.is_packed = true;
             let delta = abs_difference(array_trait.to_u64(element), self.previous_element);
-            let max_bit_number = numbits(delta);
+            let max_bit_number = bit_length(delta);
             if max_bit_number > self.max_bit_number {
                 self.max_bit_number = max_bit_number;
                 if self.max_bit_number > MAX_BIT_NUMBER_LIMIT {

--- a/src/ztype/numbits.rs
+++ b/src/ztype/numbits.rs
@@ -1,18 +1,44 @@
-// Calculates the bit length of an integer type, i.e. the numbers
-// of bits needed to represent this number.
+///  Gets the minimum number of bits required to encode given number of different values.
 /// For example:
 /// ```rust
 /// use rust_zserio::ztype::numbits;
 /// assert!(numbits(0) == 0);
 /// assert!(numbits(1) == 1);
 /// assert!(numbits(7) == 3);
-/// assert!(numbits(8) == 4);
-/// assert!(numbits(8) == 4);
+/// assert!(numbits(8) == 3);
+/// assert!(numbits(9) == 4);
+/// assert!(numbits(32) == 5);
+/// assert!(numbits(33) == 6);
 /// assert!(numbits(6917529027641081856u64) == 63);
 /// assert!(numbits(std::u64::MAX) == 64);
 /// assert!(numbits(std::u32::MAX) == 32);
 /// ```
 pub fn numbits<T: num::PrimInt>(value: T) -> u8 {
+    if T::is_zero(&value) {
+        return 0;
+    }
+    if T::is_one(&value) {
+        return 1;
+    }
+    bit_length(value - T::from(1).expect("failed to subtract 1"))
+}
+
+// Calculates the bit length of an integer type, i.e. the numbers
+// of bits needed to represent this number.
+/// For example:
+/// ```rust
+/// use rust_zserio::ztype::numbits;
+/// assert!(bit_length(0) == 0);
+/// assert!(bit_length(1) == 1);
+/// assert!(bit_length(7) == 3);
+/// assert!(bit_length(8) == 4);
+/// assert!(bit_length(8) == 4);
+/// assert!(bit_length(32) == 6);
+/// assert!(bit_length(6917529027641081856u64) == 63);
+/// assert!(bit_length(std::u64::MAX) == 64);
+/// assert!(bit_length(std::u32::MAX) == 32);
+/// ```
+pub fn bit_length<T: num::PrimInt>(value: T) -> u8 {
     let mut x = value.to_u64().expect("failed to convert to u64");
     let mut n = 0u8;
     if x >= 1 << 32 {

--- a/src/ztype/numbits.rs
+++ b/src/ztype/numbits.rs
@@ -27,7 +27,7 @@ pub fn numbits<T: num::PrimInt>(value: T) -> u8 {
 // of bits needed to represent this number.
 /// For example:
 /// ```rust
-/// use rust_zserio::ztype::numbits;
+/// use rust_zserio::ztype::bit_length;
 /// assert!(bit_length(0) == 0);
 /// assert!(bit_length(1) == 1);
 /// assert!(bit_length(7) == 3);

--- a/tests/round-trip-tests/src/expr_numbits_test.rs
+++ b/tests/round-trip-tests/src/expr_numbits_test.rs
@@ -5,14 +5,21 @@ use rust_zserio::ztype::ZserioPackableObject;
 /// The function get_num_bits() is defined as `return numbits(u16Value) + numbits(8);`.
 pub fn test_expr_numbits() {
     let mut test_struct = ExpressionNumbitsTest::new();
-    assert_eq!(test_struct.get_num_bits(), 4);
+    assert_eq!(test_struct.get_num_bits(), 3);
 
     test_struct.u_16_value = 1;
-    assert_eq!(test_struct.get_num_bits(), 5);
+    assert_eq!(test_struct.get_num_bits(), 4);
 
     test_struct.u_16_value = 7;
-    assert_eq!(test_struct.get_num_bits(), 7);
+    assert_eq!(test_struct.get_num_bits(), 6);
 
+    // as per
+    // https://zserio.org/doc/ZserioLanguageOverview.html
+    // numbits(8) + numbits(8) =
+    // 3 + 3
     test_struct.u_16_value = 8;
-    assert_eq!(test_struct.get_num_bits(), 8);
+    assert_eq!(test_struct.get_num_bits(), 6);
+
+    test_struct.u_16_value = 9;
+    assert_eq!(test_struct.get_num_bits(), 7);
 }


### PR DESCRIPTION
- there was a bug in the template instantiation of types which caused the instantiated type to lose it's template parameters. As a consequence, the type parameters were not correctly passed during reading, resulting in parsing failure.
- for writing, the problem was less direct, but missing assertions made writing the data difficult.
- this commit fixes the underlying problem by passing the parameters correctly.