### PR TITLE
Fix cargo doc warnings

### DIFF
--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -1,8 +1,9 @@
-//! This module contains dumy code that is for doctests. It should
-//! never be used.
+//! This module contains dumy code that is for doctests. It should never be
+//! used.
 //!
-//! This is a workaround until https://github.com/rust-lang/rust/issues/67295
-//! is fixed.
+//! This is a workaround until
+//! [rust-lang/rust#67295](https://github.com/rust-lang/rust/issues/67295) is
+//! fixed.
 use crate::ztype::array_traits::packing_context_node::PackingContextNode;
 use crate::{Result, ZserioPackableObject};
 use bitreader::BitReader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@
 //! ```
 //! This will generate the interface files in rust, that allow reading/writing zserio-encoded
 //! data.
-//! [Optional] The `root` CLI flag is optional, ane enforces an overall crate prefix to the generated code.
+//!
+//! The `--root` CLI flag is optional, and enforces an overall crate prefix to the generated code.
 pub mod doctest;
 mod error;
 pub mod internal;


### PR DESCRIPTION
A few small markdown syntax updates to fix warnings reported by `cargo doc`.
