### PR TITLE
Add Tests for Parameter Passing for templated Structs, Unions, and Choices; fix bugs with UTF-8 strings; add union template instantiation

### DIFF
--- a/src/internal/ast/package.rs
+++ b/src/internal/ast/package.rs
@@ -23,7 +23,7 @@ pub struct ZPackage {
     pub imports: Vec<ZImport>,
     pub structs: HashMap<String, Rc<RefCell<ZStruct>>>,
     pub zchoices: HashMap<String, Rc<RefCell<ZChoice>>>,
-    pub zunions: Vec<Rc<RefCell<ZUnion>>>,
+    pub zunions: HashMap<String, Rc<RefCell<ZUnion>>>,
     pub enums: Vec<Rc<RefCell<ZEnum>>>,
     pub consts: Vec<Rc<RefCell<ZConst>>>,
     pub subtypes: Vec<Rc<RefCell<Subtype>>>,

--- a/src/internal/compiler/symbol_scope.rs
+++ b/src/internal/compiler/symbol_scope.rs
@@ -178,7 +178,7 @@ impl PackageScope {
         for zchoice in package.zchoices.values() {
             add_choice_to_scope(zchoice, &mut scope);
         }
-        for zunion in &package.zunions {
+        for zunion in package.zunions.values() {
             add_zunion_to_scope(zunion, &mut scope);
         }
         for zenum in &package.enums {

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -6,7 +6,7 @@ use crate::internal::ast::type_reference::TypeReference;
 use crate::internal::ast::zchoice::{add_choice_to_scope, ZChoice, ZChoiceCase};
 use crate::internal::ast::zfunction::ZFunction;
 use crate::internal::ast::zstruct::{add_struct_to_scope, ZStruct};
-use crate::internal::ast::zunion::ZUnion;
+use crate::internal::ast::zunion::{add_zunion_to_scope, ZUnion};
 
 use crate::internal::compiler::symbol_scope::{ModelScope, Symbol};
 use std::cell::RefCell;
@@ -53,6 +53,16 @@ pub fn instantiate_type(
                 pkg,
                 scope,
                 &c.as_ref().borrow(),
+                &zserio_type.template_arguments,
+                &zserio_type.type_arguments,
+                &new_type_name,
+            );
+        }
+        Symbol::Union(u) => {
+            return instantiate_union(
+                pkg,
+                scope,
+                &u.as_ref().borrow(),
                 &zserio_type.template_arguments,
                 &zserio_type.type_arguments,
                 &new_type_name,
@@ -317,6 +327,116 @@ fn instantiate_choice(
 
     // Update the scope to contain the newly added structure.
     add_choice_to_scope(&pkg.zchoices[instantiated_name], scope.get_package_scope());
+    new_type_ref
+}
+
+fn instantiate_union(
+    pkg: &mut ZPackage,
+    scope: &mut ModelScope,
+    z_union: &ZUnion,
+    template_arguments: &[TypeReference],
+    type_arguments: &[Rc<RefCell<Expression>>],
+    instantiated_name: &String,
+) -> TypeReference {
+    assert!(!z_union.template_parameters.is_empty());
+    assert!(z_union.template_parameters.len() == template_arguments.len());
+
+    let new_type_ref = TypeReference {
+        is_builtin: false,
+        package: pkg.name.clone(),
+        name: instantiated_name.clone(),
+        bits: 0,
+        template_arguments: vec![],
+        type_arguments: type_arguments.to_owned(),
+        length_expression: None,
+    };
+
+    if pkg.zunions.contains_key(instantiated_name) {
+        // The union was already instantiated, there is no need to instantiate it again.
+        // Return a new reference to the already existing type.
+        return new_type_ref;
+    }
+
+    // The instantiated struct doesn't exist yet. Start by instantiating the
+    // template parameter itself.
+    let mut instantiated_types: HashMap<String, TypeReference> = HashMap::new();
+    for (index, template_arg) in template_arguments.iter().enumerate() {
+        // In case the type instantiation is a template itself, it must be instantiated
+        // before mapping it. In case the template argument itself is not a template,
+        // instantiate_type() will just pass the type through.
+        let instantiated_type = instantiate_type(pkg, scope, template_arg, "");
+        instantiated_types.insert(
+            z_union.template_parameters[index].clone(),
+            instantiated_type,
+        );
+    }
+
+    let mut instantiated_union = ZUnion {
+        name: instantiated_name.clone(),
+        comment: z_union.comment.clone(),
+        template_parameters: vec![],
+        type_parameters: vec![],
+        fields: vec![],
+        functions: vec![],
+    };
+
+    // Instantiate the fields
+    for field in &z_union.fields {
+        instantiated_union
+            .fields
+            .push(Rc::from(RefCell::from(instantiate_field(
+                pkg,
+                scope,
+                &field.borrow(),
+                &instantiated_types,
+            ))));
+    }
+    // Instantiate the parameters
+    for rc_param in &z_union.type_parameters {
+        // Check if the parameter is a templated type
+        let param = rc_param.as_ref().borrow();
+        if instantiated_types.contains_key(&param.zserio_type.name) {
+            // The parameter is a templated type, so replace the parameter
+            // type by a reference to the newly instantiated type.
+            instantiated_union
+                .type_parameters
+                .push(Rc::new(RefCell::new(Parameter {
+                    name: param.name.clone(),
+                    zserio_type: Box::new(instantiated_types[&param.zserio_type.name].clone()),
+                })));
+        } else {
+            // The parameter is not templated, and is not affected by template instantiation.
+            instantiated_union
+                .type_parameters
+                .push(Rc::new(RefCell::new(param.clone())));
+        }
+    }
+
+    for rc_function in &z_union.functions {
+        let function = rc_function.as_ref().borrow();
+        if instantiated_types.contains_key(&function.return_type.name) {
+            // The parameter is a templated type, so replace the parameter
+            // type by a reference to the newly instantiated type.
+            instantiated_union
+                .functions
+                .push(Rc::new(RefCell::new(ZFunction {
+                    name: function.name.clone(),
+                    result: function.result.clone(),
+                    return_type: Box::new(instantiated_types[&function.return_type.name].clone()),
+                })));
+        } else {
+            instantiated_union
+                .functions
+                .push(Rc::new(RefCell::new(function.clone())));
+        }
+    }
+
+    // Update the scope to contain the newly added union.
+    pkg.zunions.insert(
+        instantiated_name.clone(),
+        Rc::from(RefCell::from(instantiated_union)),
+    );
+    add_zunion_to_scope(&pkg.zunions[instantiated_name], scope.get_package_scope());
     new_type_ref
 }
 

--- a/src/internal/compiler/template_instantiation.rs
+++ b/src/internal/compiler/template_instantiation.rs
@@ -377,7 +377,7 @@ pub fn instantiate_struct_fields(
 ) {
     // template structs are not instantiated; their instantiation happens when
     // the template structs are actually used (by template instantiation).
-    if zstruct.template_parameters.len() > 0 {
+    if !zstruct.template_parameters.is_empty() {
         return;
     }
     // Instantiate field inside structs.
@@ -403,7 +403,7 @@ pub fn instantiate_choice_fields(
 ) {
     // template choice are not instantiated; their instantiation happens when
     // the template choices are actually used (by template instantiation).
-    if zchoice.template_parameters.len() > 0 {
+    if !zchoice.template_parameters.is_empty() {
         return;
     }
     // Instantiate field inside choices.
@@ -433,7 +433,7 @@ pub fn instantiate_choice_fields(
 pub fn instantiate_union_fields(pkg: &mut ZPackage, scope: &mut ModelScope, zunion: &mut ZUnion) {
     // template unions are not instantiated; their instantiation happens when
     // the templated union are actually used (by template instantiation).
-    if zunion.template_parameters.len() > 0 {
+    if !zunion.template_parameters.is_empty() {
         return;
     }
     // Instantiate field inside the union.

--- a/src/internal/generator/package.rs
+++ b/src/internal/generator/package.rs
@@ -55,7 +55,7 @@ pub fn generate_package(
     }
 
     // Generate  the rust code for zserio Union types.
-    for zunion_ref_cell in &package.zunions {
+    for zunion_ref_cell in package.zunions.values() {
         let zunion = zunion_ref_cell.borrow();
         // Ignore templates, only generate code for instantiated unions.
         if !zunion.template_parameters.is_empty() {

--- a/src/internal/model.rs
+++ b/src/internal/model.rs
@@ -98,7 +98,7 @@ impl Model {
                 scope.scope_stack.pop();
             }
 
-            for z_union in &pkg.zunions {
+            for z_union in pkg.zunions.values_mut() {
                 scope.scope_stack.push(ScopeLocation {
                     package: pkg.name.clone(),
                     import_symbol: None,
@@ -196,7 +196,7 @@ impl Model {
             }
 
             let zunions = pkg.zunions.clone();
-            for z_union in zunions {
+            for z_union in zunions.values() {
                 scope.scope_stack.push(ScopeLocation {
                     package: pkg.name.clone(),
                     import_symbol: None,
@@ -247,7 +247,7 @@ impl Model {
                 scope.scope_stack.pop();
             }
 
-            for z_union in &pkg.zunions {
+            for z_union in pkg.zunions.values_mut() {
                 scope.scope_stack.push(ScopeLocation {
                     package: pkg.name.clone(),
                     import_symbol: None,

--- a/src/internal/model.rs
+++ b/src/internal/model.rs
@@ -11,7 +11,10 @@ use walkdir::WalkDir;
 
 use super::compiler::symbol_scope::ScopeLocation;
 pub mod package;
-use crate::internal::compiler::template_instantiation::instantiate_type;
+use crate::internal::compiler::template_instantiation::{
+    instantiate_choice_fields, instantiate_struct_fields, instantiate_type,
+    instantiate_union_fields,
+};
 
 /// A data structure containing all zserio files related to each other.
 pub struct Model {
@@ -162,6 +165,45 @@ impl Model {
                         &subtype.name.clone(),
                     );
                 }
+            }
+
+            // instantiate all structs/choices/unions that are not templates themselves,
+            // but have templated fields.
+
+            // The template instantiation will generate new structs, unions, choices -
+            // to not work on a list that is modified on the fly, we take a clone of
+            // the current structs/choices/unions.
+            let zstructs = pkg.structs.clone();
+            for z_struct in zstructs.values() {
+                scope.scope_stack.push(ScopeLocation {
+                    package: pkg.name.clone(),
+                    import_symbol: None,
+                    symbol_name: Option::from(z_struct.borrow().name.clone()),
+                });
+                instantiate_struct_fields(pkg, scope, &mut z_struct.borrow_mut());
+                scope.scope_stack.pop();
+            }
+
+            let zchoices = pkg.zchoices.clone();
+            for z_choice in zchoices.values() {
+                scope.scope_stack.push(ScopeLocation {
+                    package: pkg.name.clone(),
+                    import_symbol: None,
+                    symbol_name: Option::from(z_choice.borrow().name.clone()),
+                });
+                instantiate_choice_fields(pkg, scope, &mut z_choice.borrow_mut());
+                scope.scope_stack.pop();
+            }
+
+            let zunions = pkg.zunions.clone();
+            for z_union in zunions {
+                scope.scope_stack.push(ScopeLocation {
+                    package: pkg.name.clone(),
+                    import_symbol: None,
+                    symbol_name: Option::from(z_union.borrow().name.clone()),
+                });
+                instantiate_union_fields(pkg, scope, &mut z_union.borrow_mut());
+                scope.scope_stack.pop();
             }
             scope.scope_stack.pop();
         }

--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -167,7 +167,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
             imports,
             structs: HashMap::new(),
             zchoices: HashMap::new(),
-            zunions: vec![],
+            zunions: HashMap::new(),
             enums: vec![],
             consts: vec![],
             subtypes: vec![],
@@ -196,7 +196,8 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                                 package.consts.push(Rc::new(RefCell::new(*c)))
                             }
                             ZserioTreeReturnType::Union(u) => {
-                                package.zunions.push(Rc::new(RefCell::new(*u)))
+                                let name = u.name.clone();
+                                package.zunions.insert(name, Rc::new(RefCell::new(*u)));
                             }
                             ZserioTreeReturnType::Subtype(s) => {
                                 package.subtypes.push(Rc::new(RefCell::new(*s)))

--- a/src/ztype/string_encode.rs
+++ b/src/ztype/string_encode.rs
@@ -6,10 +6,12 @@ use crate::ztype::unsigned_bitsize;
 use super::varuint_encode::write_varsize;
 
 pub fn write_string(writer: &mut BitWriter, s: &str) -> Result<()> {
-    write_varsize(writer, s.len() as u32)?;
+    let string_bytes = s.as_bytes();
 
-    for c in s.chars() {
-        writer.write_u8(c as u8, 8)?;
+    write_varsize(writer, string_bytes.len() as u32)?;
+
+    for string_byte in string_bytes {
+        writer.write_u8(*string_byte, 8)?;
     }
     Ok(())
 }

--- a/tests/reference_modules/all.zs
+++ b/tests/reference_modules/all.zs
@@ -9,6 +9,7 @@ import reference_modules.type_lookup_test.ztype.*;
 import reference_modules.type_lookup_test.other_ztype.*;
 import reference_modules.parameter_passing.index_operator.*;
 import reference_modules.parameter_passing.parameter_passing.*;
+import reference_modules.parameter_passing_templates.parameter_passing_templates.*;
 import reference_modules.parameter_passing_bitmask.parameter_passing_bitmask.*;
 import reference_modules.ambiguous_types.main.*;
 import reference_modules.ambiguous_types.other.*;

--- a/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
+++ b/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
@@ -13,6 +13,13 @@ struct ParameterPassingTemplates
 
     // Test passing of parameters to an array.
     TemplatedBlock<uint64>(numElements) templated_blocks[2];
+
+    TemplatedUnion<uint32, string>(numElements) templated_union;
+    TemplatedUnion<uint32, string>(numElements) templated_unions[2];
+
+    uint32 selector;
+    TemplatedChoice<uint32, string>(selector) templated_choice;
+    TemplatedChoice<uint32, string>(selector) templated_choices[2];
 };
 
 struct TemplatedBlock<ITEM_T>(uint32 numElements)
@@ -27,8 +34,7 @@ struct TemplatedBlock<ITEM_T>(uint32 numElements)
 union TemplatedUnion<ITEM_T, ITEM_U>(uint32 numElements)
 {
     ITEM_T value1;
-    ITEM_U value2;
-
+    ITEM_U value2[numElements];
 };
 
 choice TemplatedChoice<ITEM_T, ITEM_U>(uint32 selector) on selector
@@ -37,5 +43,4 @@ choice TemplatedChoice<ITEM_T, ITEM_U>(uint32 selector) on selector
         ITEM_T value1;
     case 1:
         ITEM_U value2;
-
 };

--- a/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
+++ b/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
@@ -1,0 +1,41 @@
+package reference_modules.parameter_passing_templates.parameter_passing_templates;
+
+// This is a variant of the parameterized test, using
+// templated structs, union and choices to stress
+// the parameter passing.
+struct ParameterPassingTemplates
+{
+    uint16 numBlocks;
+    uint32 numElements;
+
+    // Test passing of parameters to a single instance.
+    TemplatedBlock<string>(numElements)  block;
+
+    // Test passing of parameters to an array.
+    TemplatedBlock<uint64>(numElements) blocks[2];
+};
+
+struct TemplatedBlock<ITEM_T>(uint32 numElements)
+{
+    ITEM_T items[numElements];
+
+    // Add a conditional item, that depends on the parameter passed in the index.
+    // This ensures that during serialization / deserialization, the item is correctly passed.
+    uint8 conditionItem if numElements > 0;
+};
+
+union TemplatedUnion<ITEM_T, ITEM_U>(uint32 numElements)
+{
+    ITEM_T value1;
+    ITEM_U value2;
+
+};
+
+choice TemplatedChoice<ITEM_T, ITEM_U>(uint32 selector) on selector
+{
+    case 0:
+        ITEM_T value1;
+    case 1:
+        ITEM_U value2;
+
+};

--- a/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
+++ b/tests/reference_modules/parameter_passing_templates/parameter_passing_templates.zs
@@ -9,10 +9,10 @@ struct ParameterPassingTemplates
     uint32 numElements;
 
     // Test passing of parameters to a single instance.
-    TemplatedBlock<string>(numElements)  block;
+    TemplatedBlock<string>(numElements)  templated_block;
 
     // Test passing of parameters to an array.
-    TemplatedBlock<uint64>(numElements) blocks[2];
+    TemplatedBlock<uint64>(numElements) templated_blocks[2];
 };
 
 struct TemplatedBlock<ITEM_T>(uint32 numElements)

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -10,6 +10,7 @@ pub mod offsets_test;
 pub mod optional_values_test;
 pub mod packed_arrays_test;
 pub mod parameter_passing_bitmask_test;
+pub mod parameter_passing_templates_test;
 pub mod parameter_passing_test;
 pub mod parameterized_array_length_test;
 pub mod subtyped_dot_expression;
@@ -47,6 +48,7 @@ use crate::optional_values_test::{
 };
 use crate::packed_arrays_test::test_packed_arrays;
 use crate::parameter_passing_bitmask_test::test_passing_bitmask_parameter;
+use crate::parameter_passing_templates_test::test_parameter_passing_templates;
 use crate::parameter_passing_test::{test_index_operator, test_parameter_passing};
 use crate::parameterized_array_length_test::test_parameterized_array_length;
 use crate::subtyped_dot_expression::test_subtyped_dot_expression;
@@ -63,6 +65,7 @@ fn main() {
     test_type_lookup();
     test_union_type();
     test_parameter_passing();
+    test_parameter_passing_templates();
     test_passing_bitmask_parameter();
     test_index_operator();
     test_ambiguous_types();

--- a/tests/round-trip-tests/src/parameter_passing_templates_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_templates_test.rs
@@ -1,0 +1,101 @@
+use reference_module_lib::reference_modules::parameter_passing_templates::parameter_passing_templates::{
+    parameter_passing_templates::ParameterPassingTemplates,
+    templated_blockstring::TemplatedBlockstring,
+    templated_blockuint_64::TemplatedBlockuint64,
+    templated_choiceuint_32_string::TemplatedChoiceuint32String,
+    templated_unionuint_32_string::TemplatedUnionuint32String,
+    templated_unionuint_32_string::TemplatedUnionuint32StringSelector,
+};
+
+use bitreader::BitReader;
+use rust_bitwriter::BitWriter;
+use rust_zserio::ztype::ZserioPackableObject;
+
+pub fn test_parameter_passing_templates() {
+    // Create a test structure, which uses parameter passing on template types
+    let test_struct: ParameterPassingTemplates = ParameterPassingTemplates {
+        num_blocks: 2,
+        num_elements: 3,
+        templated_block: TemplatedBlockstring {
+            num_elements: 3,
+            items: vec![
+                String::from("foo"),
+                String::from("bar"),
+                String::from("foobar"),
+            ],
+            condition_item: 10,
+        },
+        templated_blocks: vec![
+            TemplatedBlockuint64 {
+                num_elements: 3,
+                items: vec![100, 101, 102],
+                condition_item: 10,
+            },
+            TemplatedBlockuint64 {
+                num_elements: 3,
+                items: vec![200, 201, 202],
+                condition_item: 10,
+            },
+        ],
+        templated_union: TemplatedUnionuint32String {
+            num_elements: 3,
+            union_selector: TemplatedUnionuint32StringSelector::Value1,
+            value_1: 42042,
+            value_2: vec![], // ignored
+        },
+        templated_unions: vec![
+            TemplatedUnionuint32String {
+                num_elements: 3,
+                union_selector: TemplatedUnionuint32StringSelector::Value2,
+                value_1: 0, // ignored
+                value_2: vec![
+                    String::from("芝麻包"),
+                    String::from("叉烧包"),
+                    String::from("流沙包"),
+                ],
+            },
+            TemplatedUnionuint32String {
+                num_elements: 3,
+                union_selector: TemplatedUnionuint32StringSelector::Value1,
+                value_1: 195373,
+                value_2: vec![], // ignored
+            },
+        ],
+        selector: 1,
+        templated_choice: TemplatedChoiceuint32String {
+            selector: 1,
+            value_1: 0, // ignored
+            value_2: String::from("干炒牛河"),
+        },
+        templated_choices: vec![
+            TemplatedChoiceuint32String {
+                selector: 1,
+                value_1: 0, // ignored
+                value_2: String::from("炸酱面"),
+            },
+            TemplatedChoiceuint32String {
+                selector: 1,
+                value_1: 0, // ignored
+                value_2: String::from(""),
+            },
+        ],
+    };
+
+    // serialize
+    let mut bitwriter = BitWriter::new();
+    test_struct
+        .zserio_write(&mut bitwriter)
+        .expect("can not write zserio data");
+    bitwriter.close().expect("failed to close bit stream");
+    let serialized_bytes = bitwriter.data();
+
+    // deserialize
+    let mut other_test_struct = ParameterPassingTemplates::new();
+    let mut bitreader = BitReader::new(serialized_bytes);
+    other_test_struct
+        .zserio_read(&mut bitreader)
+        .expect("can not read zserio data");
+
+    // expect them to be identical.
+    assert!(test_struct == other_test_struct);
+}


### PR DESCRIPTION
Adds tests for https://github.com/Danaozhong/rust-zserio/pull/88 .

It adds test cases that use instantiated templates, such as:
```
struct ZStruct {
    TemplateType<int32> field;
};
```
and combines these (and equivalent `choice` and `union` types) with parameters.

To spice things up, the test uses some Chinese strings to stress the string decoder.

If everything works correctly:
- the code that generates the templates should run, and generate the template instantiations
- the generated code should comply.
- the types should serialize without issues, with all non-used/not active fields being ignored.
- when deserialized, the resulting data should match the original data.