### PR TITLE
Drop new() function

### DIFF
--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -16,9 +16,6 @@ pub struct DrinkOrder {
 }
 
 impl ZserioPackableObject for DrinkOrder {
-    fn new() -> Self {
-        Self::default()
-    }
     fn zserio_read(&mut self, _: &mut BitReader) -> Result<()> {
         Ok(())
     }

--- a/src/internal/generator/zbitmask.rs
+++ b/src/internal/generator/zbitmask.rs
@@ -62,11 +62,6 @@ pub fn generate_bitmask(
     let z_impl = bitmask_scope.new_impl(&rust_type_name);
     z_impl.impl_trait("ztype::ZserioPackableObject");
 
-    // Generate a function to create a new instance of the enum
-    let new_fn: &mut codegen::Function = z_impl.new_fn("new");
-    new_fn.ret("Self");
-    new_fn.line("Self::default()");
-
     // generate the functions to serialize/deserialize
     generate_zserio_read(scope, type_generator, z_impl, zbitmask, &fundamental_type);
     generate_zserio_write(scope, type_generator, z_impl, &fundamental_type);

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -86,11 +86,6 @@ pub fn generate_choice(
     let choice_impl = codegen_scope.new_impl(&rust_type_name);
     choice_impl.impl_trait("ztype::ZserioPackableObject");
 
-    // Generate a function to create a new instance of the struct
-    let new_fn = choice_impl.new_fn("new");
-    new_fn.ret("Self");
-    new_fn.line("Self::default()");
-
     generate_zserio_read(symbol_scope, type_generator, choice_impl, zchoice);
     generate_zserio_write(symbol_scope, type_generator, choice_impl, zchoice);
     generate_zserio_bitsize(symbol_scope, type_generator, choice_impl, zchoice);

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -87,11 +87,6 @@ pub fn generate_enum(
     let z_impl = gen_scope.new_impl(&rust_type_name);
     z_impl.impl_trait("ztype::ZserioPackableObject");
 
-    // Generate a function to create a new instance of the enum
-    let new_fn = z_impl.new_fn("new");
-    new_fn.ret("Self");
-    new_fn.line("Self::default()");
-
     // generate the functions to serialize/deserialize
     generate_zserio_read(scope, type_generator, z_impl, zenum, &fundamental_type);
     generate_zserio_write(scope, type_generator, z_impl, zenum, &fundamental_type);

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -83,11 +83,6 @@ pub fn generate_struct(
     let struct_impl = codegen_scope.new_impl(&rust_type_name);
     struct_impl.impl_trait("ztype::ZserioPackableObject");
 
-    // Generate a function to create a new instance of the struct
-    let new_fn = struct_impl.new_fn("new");
-    new_fn.ret("Self");
-    new_fn.line("Self::default()");
-
     // Generate the functions to read, write and bitcount the data to/from zserio format.
     generate_zserio_read(symbol_scope, type_generator, struct_impl, &field_details);
     generate_zserio_write(symbol_scope, type_generator, struct_impl, &field_details);

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -119,11 +119,6 @@ pub fn generate_union(
     let union_impl = codegen_scope.new_impl(&rust_type_name);
     union_impl.impl_trait("ztype::ZserioPackableObject");
 
-    // Generate a function to create a new instance of the struct
-    let new_fn = union_impl.new_fn("new");
-    new_fn.ret("Self");
-    new_fn.line("Self::default()");
-
     // Generate the functions to read, write and bitcount the data to/from zserio format.
     generate_zserio_read(symbol_scope, type_generator, union_impl, zunion);
     generate_zserio_write(symbol_scope, type_generator, union_impl, zunion);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn to_writer<W: std::io::Write, T: ZserioPackableObject>(
 /// enough data in the slice.
 pub fn from_bytes<T: ZserioPackableObject>(data: &[u8]) -> self::error::Result<T> {
     let mut bitreader = BitReader::new(data);
-    let mut v = T::new();
+    let mut v: T = Default::default();
     v.zserio_read(&mut bitreader)?;
     Ok(v)
 }

--- a/src/ztype/traits.rs
+++ b/src/ztype/traits.rs
@@ -3,8 +3,7 @@ use crate::ztype::array_traits::packing_context_node::PackingContextNode;
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
 
-pub trait ZserioPackableObject {
-    fn new() -> Self;
+pub trait ZserioPackableObject: Default {
     fn zserio_read(&mut self, reader: &mut BitReader) -> Result<()>;
     fn zserio_write(&self, writer: &mut BitWriter) -> Result<()>;
     fn zserio_read_packed(

--- a/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
+++ b/tests/compare-ref-impl-tests/rust/src/offsets_test.rs
@@ -1,10 +1,8 @@
+use crate::deserialize_artifacts::read_from_python_and_compare;
 use reference_module_lib::reference_modules::offsets::offsets::offsets::Offsets;
 
-use crate::deserialize_artifacts::read_from_python_and_compare;
-use rust_zserio::ztype::ZserioPackableObject;
-
 pub fn offsets_test() {
-    let mut test_obj = Offsets::new();
+    let mut test_obj = Offsets::default();
     read_from_python_and_compare("offsets_test", &mut test_obj)
         .expect("can not compare with python");
 }

--- a/tests/compare-ref-impl-tests/rust/src/packed_arrays_test.rs
+++ b/tests/compare-ref-impl-tests/rust/src/packed_arrays_test.rs
@@ -1,10 +1,8 @@
+use crate::deserialize_artifacts::read_from_python_and_compare;
 use reference_module_lib::reference_modules::packed_arrays::packed_arrays::packed_array_wrapper::PackedArrayWrapper;
 
-use crate::deserialize_artifacts::read_from_python_and_compare;
-use rust_zserio::ztype::ZserioPackableObject;
-
 pub fn packed_arrays_test() {
-    let mut test_obj = PackedArrayWrapper::new();
+    let mut test_obj = PackedArrayWrapper::default();
     read_from_python_and_compare("packed_arrays_test", &mut test_obj)
         .expect("can not compare with python");
 }

--- a/tests/reference-module-lib/src/lib.rs
+++ b/tests/reference-module-lib/src/lib.rs
@@ -51,6 +51,9 @@ pub mod reference_modules {
     pub mod parameter_passing_bitmask {
         pub mod parameter_passing_bitmask;
     }
+    pub mod parameter_passing_templates {
+        pub mod parameter_passing_templates;
+    }
     pub mod parameterized_array_length {
         pub mod parameterized_array_length;
     }

--- a/tests/round-trip-tests/src/alignment_test.rs
+++ b/tests/round-trip-tests/src/alignment_test.rs
@@ -2,11 +2,10 @@ use reference_module_lib::reference_modules::alignment::alignment::alignment_str
 
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
-use rust_zserio::ztype::ZserioPackableObject;
-use rust_zserio::Result;
+use rust_zserio::{Result, ZserioPackableObject};
 
 pub fn test_alignment() -> Result<()> {
-    let mut test_struct = AlignmentStruct::new();
+    let mut test_struct = AlignmentStruct::default();
 
     // Even though bo_value_4 is not set, the alignment of the field is still taken into
     // account, because the "is present" bit is written, and this bit takes the alignment
@@ -23,8 +22,10 @@ pub fn test_alignment() -> Result<()> {
 }
 
 pub fn test_alignment_roundtrip() -> Result<()> {
-    let mut test_struct = AlignmentStruct::new();
-    test_struct.bo_value_4 = Some(true);
+    let mut test_struct = AlignmentStruct {
+        bo_value_4: Some(true),
+        ..Default::default()
+    };
     // Set the condition to serialize bo_value_5 to true (bo_value_5 depends on bo_value_3).
     test_struct.bo_value_3 = true;
 
@@ -36,7 +37,7 @@ pub fn test_alignment_roundtrip() -> Result<()> {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = AlignmentStruct::new();
+    let mut other_test_struct = AlignmentStruct::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct.zserio_read(&mut bitreader)?;
 

--- a/tests/round-trip-tests/src/ambiguous_types_test.rs
+++ b/tests/round-trip-tests/src/ambiguous_types_test.rs
@@ -1,9 +1,8 @@
 use reference_module_lib::reference_modules::ambiguous_types::main::ambiguous_types_struct::AmbiguousTypesStruct;
-use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn test_ambiguous_types() {
     // Create a test structure, and assign a new instance.
     // If this line compiles, the test passes.
-    let mut test_struct = AmbiguousTypesStruct::new();
-    test_struct.value = 17;
+    let mut test_struct = AmbiguousTypesStruct { value: 17 };
+    test_struct.value = 18;
 }

--- a/tests/round-trip-tests/src/bitmask_isset_test.rs
+++ b/tests/round-trip-tests/src/bitmask_isset_test.rs
@@ -2,14 +2,14 @@ use reference_module_lib::reference_modules::bitmask_isset::bitmask_isset::{
     bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask,
 };
 
-use rust_zserio::ztype::ZserioPackableObject;
-
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
+use rust_zserio::ZserioPackableObject;
 
 pub fn test_bitmask_isset_round_trip() {
-    let mut test_struct = BitmaskTest::new();
-    test_struct.value = SomeBitMask::FlagA | SomeBitMask::FlagB;
+    let test_struct = BitmaskTest {
+        value: SomeBitMask::FlagA | SomeBitMask::FlagB,
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -20,7 +20,7 @@ pub fn test_bitmask_isset_round_trip() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = BitmaskTest::new();
+    let mut other_test_struct = BitmaskTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)
@@ -31,8 +31,9 @@ pub fn test_bitmask_isset_round_trip() {
 }
 
 pub fn test_bitmask_isset_operator() {
-    let mut test_struct = BitmaskTest::new();
-    test_struct.value = SomeBitMask::FlagA | SomeBitMask::FlagB;
+    let mut test_struct = BitmaskTest {
+        value: SomeBitMask::FlagA | SomeBitMask::FlagB,
+    };
 
     // Ensure that the isset() operator works correctly.
     assert!(test_struct.has_a());

--- a/tests/round-trip-tests/src/bitmask_test.rs
+++ b/tests/round-trip-tests/src/bitmask_test.rs
@@ -8,12 +8,12 @@ use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
 
 pub fn test_bitmasks() {
-    let mut test_struct = BitmaskTest::new();
-    test_struct.selector = SomeBitMask::HasA | SomeBitMask::HasB;
-
-    test_struct.value_a = 123;
-    test_struct.value_b = 456;
-    test_struct.value_c = 678; // Should be ignored.
+    let test_struct = BitmaskTest {
+        selector: SomeBitMask::HasA | SomeBitMask::HasB,
+        value_a: 123,
+        value_b: 456,
+        value_c: 678, // Should be ignored.
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -24,7 +24,7 @@ pub fn test_bitmasks() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = BitmaskTest::new();
+    let mut other_test_struct = BitmaskTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/constants_test.rs
+++ b/tests/round-trip-tests/src/constants_test.rs
@@ -1,14 +1,13 @@
 use reference_module_lib::reference_modules::constants::constants::constant_test_struct::ConstantTestStruct;
 
-use rust_zserio::ztype::ZserioPackableObject;
-
 pub fn test_constants() {
     // The test structure created in this test generates a function that
     // requires a lot of type casts.
     // The test passes if the generated structure compiles.
-    let mut test_struct = ConstantTestStruct::new();
-    test_struct.str_value = String::from("StrValue");
-    test_struct.other_str_value = String::from("Other");
+    let test_struct = ConstantTestStruct {
+        str_value: String::from("StrValue"),
+        other_str_value: String::from("Other"),
+    };
 
     // CONSTANT_STRING + "DummyString" + CONSTANT_STRING;
     let expected_result = "TestDummyStringTest";

--- a/tests/round-trip-tests/src/debug_trait_test.rs
+++ b/tests/round-trip-tests/src/debug_trait_test.rs
@@ -1,15 +1,16 @@
 use reference_module_lib::reference_modules::core::types::color::Color;
 use reference_module_lib::reference_modules::core::types::value_wrapper::ValueWrapper;
-use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn test_debug_trait() {
-    let mut value_wrapper = ValueWrapper::new();
-    value_wrapper.parameter = 7;
-    value_wrapper.value = 14;
-    value_wrapper.enum_value = Color::Red;
-    value_wrapper.description = "test".into();
-    value_wrapper.fixed_array = vec![100, 101, 102, 103];
-    value_wrapper.packed_array = vec![200, 201, 202, 203, 205, 204];
+    let value_wrapper = ValueWrapper {
+        parameter: 7,
+        value: 14,
+        enum_value: Color::Red,
+        description: "test".into(),
+        fixed_array: vec![100, 101, 102, 103],
+        packed_array: vec![200, 201, 202, 203, 205, 204],
+        ..Default::default()
+    };
 
     assert_eq!(
         format!("{value_wrapper:?}"),

--- a/tests/round-trip-tests/src/expr_numbits_test.rs
+++ b/tests/round-trip-tests/src/expr_numbits_test.rs
@@ -1,10 +1,9 @@
 use reference_module_lib::reference_modules::expr_numbits::expr_numbits::expression_numbits_test::ExpressionNumbitsTest;
-use rust_zserio::ztype::ZserioPackableObject;
 
 /// Tests a zserio struct, which uses a function with the numbits() operator.
 /// The function get_num_bits() is defined as `return numbits(u16Value) + numbits(8);`.
 pub fn test_expr_numbits() {
-    let mut test_struct = ExpressionNumbitsTest::new();
+    let mut test_struct = ExpressionNumbitsTest::default();
     assert_eq!(test_struct.get_num_bits(), 3);
 
     test_struct.u_16_value = 1;

--- a/tests/round-trip-tests/src/integer_types_test.rs
+++ b/tests/round-trip-tests/src/integer_types_test.rs
@@ -33,7 +33,7 @@ pub fn test_integer_types() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = IntegerTypesTest::new();
+    let mut other_test_struct = IntegerTypesTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/main.rs
+++ b/tests/round-trip-tests/src/main.rs
@@ -95,13 +95,15 @@ fn test_structure() -> Result<()> {
     // that the data is still the same.
 
     // Instantiate the data
-    let mut value_wrapper = value_wrapper::ValueWrapper::new();
-    value_wrapper.parameter = 7;
-    value_wrapper.value = 14;
-    value_wrapper.enum_value = Color::Red; // this field only gets serialized, if parameter = 7
-    value_wrapper.description = "test".into();
-    value_wrapper.fixed_array = vec![100, 101, 102, 103];
-    value_wrapper.packed_array = vec![200, 201, 202, 203, 205, 204];
+    let value_wrapper = value_wrapper::ValueWrapper {
+        parameter: 7,
+        value: 14,
+        enum_value: Color::Red, // this field only gets serialized, if parameter: 7
+        description: "test".into(),
+        fixed_array: vec![100, 101, 102, 103],
+        packed_array: vec![200, 201, 202, 203, 205, 204],
+        ..Default::default()
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -110,10 +112,10 @@ fn test_structure() -> Result<()> {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_value_wrapper = value_wrapper::ValueWrapper::new();
-
-    // Pass parameters.
-    other_value_wrapper.parameter = 7;
+    let mut other_value_wrapper = value_wrapper::ValueWrapper {
+        parameter: 7,
+        ..Default::default()
+    };
 
     // Deserialize.
     let mut bitreader = BitReader::new(serialized_bytes);
@@ -140,9 +142,11 @@ fn test_functions() {
     // that the function is generated correctly.
 
     // Instantiate the data
-    let mut value_wrapper = value_wrapper::ValueWrapper::new();
-    value_wrapper.parameter = 2;
-    value_wrapper.value = 9;
+    let value_wrapper = value_wrapper::ValueWrapper {
+        parameter: 2,
+        value: 9,
+        ..Default::default()
+    };
     // Call the function, and expect it to return the correct value.
     assert!(value_wrapper.get_some_random_value() == 36)
 }
@@ -151,9 +155,11 @@ fn test_choice() {
     // that the data is identical to what was serialized.
     let choice_param = SomeEnum::AttrC;
 
-    let mut basic_choice = BasicChoice::new();
-    basic_choice.z_type = choice_param;
-    basic_choice.field_c = 42;
+    let basic_choice = BasicChoice {
+        z_type: choice_param,
+        field_c: 42,
+        ..Default::default()
+    };
 
     // Serialize to binary.
     let mut bitwriter = BitWriter::new();
@@ -164,8 +170,11 @@ fn test_choice() {
     let serialized_bytes = bitwriter.data();
 
     // Deserialize the binary stream.
-    let mut other_basic_choice = BasicChoice::new();
-    other_basic_choice.z_type = choice_param;
+    let mut other_basic_choice = BasicChoice {
+        z_type: choice_param,
+        ..Default::default()
+    };
+
     let mut bitreader = BitReader::new(serialized_bytes);
     other_basic_choice
         .zserio_read(&mut bitreader)
@@ -186,7 +195,7 @@ fn test_choice() {
 fn test_template_instantiation() {
     // This function tests that templates can be successfully instantiated, and their
     // generated types can be serialized and deserialized.
-    let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
+    let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::default();
     z_struct.field.description = "Test Description".into();
     z_struct.field.fixed_array = vec![0, 1, 2, 3];
 
@@ -199,7 +208,7 @@ fn test_template_instantiation() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
+    let mut other_struct = instantiated_template_struct::InstantiatedTemplateStruct::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_struct
         .zserio_read(&mut bitreader)
@@ -212,7 +221,7 @@ fn test_template_instantiation() {
 fn test_functions_in_instantiated_templates() {
     // This function tests that templates can be successfully instantiated, functions that rely on
     // template properties (e.g. "T.getValue()") that are unknown before tempalte instantiation.
-    let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::new();
+    let mut z_struct = instantiated_template_struct::InstantiatedTemplateStruct::default();
     z_struct.field.description = "Test Description".into();
     z_struct.parameter = 15;
     z_struct.field.value = 32;
@@ -222,7 +231,7 @@ fn test_functions_in_instantiated_templates() {
 /// This test case tests that extern types (that store bit buffers) and bytes types (that store
 /// byte buffers) can be serialized and deserialized without changes.
 fn test_extern_type() {
-    let mut extern_test_struct = ExternTestCase::new();
+    let mut extern_test_struct = ExternTestCase::default();
 
     // fill the extern buffer with three bytes and three bits
     extern_test_struct.extern_buffer.data_blob = vec![0xf1, 0xaa, 0x12, 0xe0];
@@ -241,7 +250,7 @@ fn test_extern_type() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_struct = ExternTestCase::new();
+    let mut other_struct = ExternTestCase::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_struct
         .zserio_read(&mut bitreader)
@@ -252,7 +261,7 @@ fn test_extern_type() {
 }
 
 fn test_type_lookup() {
-    let mut ztype_struct = ZTypeStruct::new();
+    let mut ztype_struct = ZTypeStruct::default();
     // If this line compiles, the test is already successful. That means that the correct type
     // got looked up (integer).
     ztype_struct.ztype.ztype = 16;
@@ -268,11 +277,12 @@ fn test_type_lookup() {
 fn test_union_type() {
     // This test case checks union types, by creating them, assigning a value,
     // and then performing a round-trip test.
-    let mut union_instance = UnionType::new();
-
-    // fill the bytes buffer with four bytes
-    union_instance.u_16_value = 32;
-    union_instance.union_selector = UnionTypeSelector::U16Value;
+    let union_instance = UnionType {
+        // fill the bytes buffer with four bytes
+        u_16_value: 32,
+        union_selector: UnionTypeSelector::U16Value,
+        ..Default::default()
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -283,7 +293,7 @@ fn test_union_type() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_union_instance = UnionType::new();
+    let mut other_union_instance = UnionType::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_union_instance
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/offsets_test.rs
+++ b/tests/round-trip-tests/src/offsets_test.rs
@@ -5,19 +5,19 @@ use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn test_offsets() {
-    let mut test_struct = Offsets::new();
-
-    test_struct.u_32_offset = 1;
-    test_struct.vi_32_array = vec![10, 11, 13];
-    test_struct.vi_16_offset_array = vec![1, 3, 2, 7, -12];
-    test_struct.u_32_array_offset = vec![1, 3, 2, 4, 2];
-    test_struct.vi_64_index_offset_array = vec![100, 102, -2435425, -32543, 1510001];
-    test_struct.u_8_check = 127;
-    test_struct.u_16_final_check = 5523;
-    test_struct.has_flag = false;
-    test_struct.u_16_offset = 4;
-    test_struct.u_32_value = 242; // this value should not be stored, because it depends on `has_flag`.
-    test_struct.u_16_yet_final_check = 42;
+    let mut test_struct = Offsets {
+        u_32_offset: 1,
+        vi_32_array: vec![10, 11, 13],
+        vi_16_offset_array: vec![1, 3, 2, 7, -12],
+        u_32_array_offset: vec![1, 3, 2, 4, 2],
+        vi_64_index_offset_array: vec![100, 102, -2435425, -32543, 1510001],
+        u_8_check: 127,
+        u_16_final_check: 5523,
+        has_flag: false,
+        u_16_offset: 4,
+        u_32_value: 242, // this value should not be stored, because it depends on `has_flag`
+        u_16_yet_final_check: 42,
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -28,7 +28,7 @@ pub fn test_offsets() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = Offsets::new();
+    let mut other_test_struct = Offsets::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)
@@ -51,7 +51,7 @@ pub fn test_offsets() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = Offsets::new();
+    let mut other_test_struct = Offsets::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/optional_values_test.rs
+++ b/tests/round-trip-tests/src/optional_values_test.rs
@@ -7,11 +7,13 @@ use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn test_optional_values() {
-    let mut test_struct = OptionalValuesTest::new();
-    test_struct.field_selector = OptionEnum::HasB;
-    test_struct.field_a = 123; // Should be ignored.
-    test_struct.field_b = 456; // Should be serialized.
-    test_struct.field_c = 789; // Should be ignored.
+    let test_struct = OptionalValuesTest {
+        field_selector: OptionEnum::HasB,
+        field_a: 123, // Should be ignored.
+        field_b: 456, // Should be serialized.
+        field_c: 789, // Should be ignored.
+        ..Default::default()
+    };
 
     // serialize
     let mut bitwriter = BitWriter::new();
@@ -22,7 +24,7 @@ pub fn test_optional_values() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = OptionalValuesTest::new();
+    let mut other_test_struct = OptionalValuesTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)
@@ -38,9 +40,11 @@ pub fn test_optional_values() {
 }
 
 pub fn test_optional_members() {
-    let mut test_struct = OptionalValuesTest::new();
-    test_struct.option_str_field = Some("Test".to_owned());
-    test_struct.option_custom_str_field = Some("OtherTest".to_owned());
+    let test_struct = OptionalValuesTest {
+        option_str_field: Some("Test".to_owned()),
+        option_custom_str_field: Some("OtherTest".to_owned()),
+        ..Default::default()
+    };
     // serialize
     let mut bitwriter = BitWriter::new();
     test_struct
@@ -50,7 +54,7 @@ pub fn test_optional_members() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = OptionalValuesTest::new();
+    let mut other_test_struct = OptionalValuesTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)
@@ -65,12 +69,14 @@ pub fn test_optional_members() {
 /// It ensures that zserio structures with optional arrays compile, and the arrays can be correctly
 /// set and deserialized.
 pub fn test_optional_arrays() {
-    let mut test_struct = OptionalValuesTest::new();
-    test_struct.option_string_array = Some(vec![
-        "Hokkien Mee".to_string(),
-        "Kaya Toast".to_string(),
-        "Char Kway Teow".to_string(),
-    ]);
+    let test_struct = OptionalValuesTest {
+        option_string_array: Some(vec![
+            "Hokkien Mee".to_string(),
+            "Kaya Toast".to_string(),
+            "Char Kway Teow".to_string(),
+        ]),
+        ..Default::default()
+    };
     // serialize
     let mut bitwriter = BitWriter::new();
     test_struct
@@ -80,7 +86,7 @@ pub fn test_optional_arrays() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = OptionalValuesTest::new();
+    let mut other_test_struct = OptionalValuesTest::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/packed_arrays_test.rs
+++ b/tests/round-trip-tests/src/packed_arrays_test.rs
@@ -11,8 +11,12 @@ use std::{fs::File, io::Write};
 
 fn get_test_data() -> PackedArrayWrapper {
     let mut test_struct = PackedArrayWrapper {
-        packed_array: vec![DataStruct::new(), DataStruct::new(), DataStruct::new()],
-        standard_array: vec![DataStruct::new(), DataStruct::new()],
+        packed_array: vec![
+            DataStruct::default(),
+            DataStruct::default(),
+            DataStruct::default(),
+        ],
+        standard_array: vec![DataStruct::default(), DataStruct::default()],
     };
 
     test_struct.packed_array[0].u_32_packed_array = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -61,7 +65,7 @@ pub fn test_packed_arrays() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = PackedArrayWrapper::new();
+    let mut other_test_struct = PackedArrayWrapper::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     let mut new_context_node = PackingContextNode::new();
     PackedArrayWrapper::zserio_create_packing_context(&mut new_context_node);

--- a/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
@@ -10,7 +10,7 @@ pub fn test_passing_bitmask_parameter() {
     // Create a test structure, which uses parameter passing
     let mut test_struct = ParameterPassingBitmask {
         some_mask: SomeBitMask::HasA,
-        block: Item::new(),
+        block: Item::default(),
     };
 
     // We will assign a random value to the optional field, then
@@ -41,7 +41,7 @@ fn serialize_and_deserialize(test_obj: &ParameterPassingBitmask) -> ParameterPas
         .expect("can not write zserio data");
     let serialized_bytes = bitwriter.data();
 
-    let mut other_test_struct = ParameterPassingBitmask::new();
+    let mut other_test_struct = ParameterPassingBitmask::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/parameter_passing_templates_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_templates_test.rs
@@ -90,7 +90,7 @@ pub fn test_parameter_passing_templates() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = ParameterPassingTemplates::new();
+    let mut other_test_struct = ParameterPassingTemplates::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/parameter_passing_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_test.rs
@@ -39,7 +39,7 @@ pub fn test_parameter_passing() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = ParameterPassing::new();
+    let mut other_test_struct = ParameterPassing::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/parameterized_array_length_test.rs
+++ b/tests/round-trip-tests/src/parameterized_array_length_test.rs
@@ -28,7 +28,7 @@ pub fn test_parameterized_array_length() -> Result<()> {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = ParameterizedArrayLength::new();
+    let mut other_test_struct = ParameterizedArrayLength::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/subtyped_dot_expression.rs
+++ b/tests/round-trip-tests/src/subtyped_dot_expression.rs
@@ -6,9 +6,11 @@ use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::ZserioPackableObject;
 
 pub fn test_subtyped_dot_expression() {
-    let mut test_struct = TestStruct::new();
-    test_struct.value_1 = SubtypedEnum::TestValueB;
-    test_struct.opt_value_2 = 20;
+    let test_struct = TestStruct {
+        value_1: SubtypedEnum::TestValueB,
+        opt_value_2: 20,
+        ..Default::default()
+    };
 
     // serialize.
     let mut bitwriter = BitWriter::new();
@@ -19,7 +21,7 @@ pub fn test_subtyped_dot_expression() {
     let serialized_bytes = bitwriter.data();
 
     // deserialize
-    let mut other_test_struct = TestStruct::new();
+    let mut other_test_struct = TestStruct::default();
     let mut bitreader = BitReader::new(serialized_bytes);
     other_test_struct
         .zserio_read(&mut bitreader)

--- a/tests/round-trip-tests/src/template_instantiation_test.rs
+++ b/tests/round-trip-tests/src/template_instantiation_test.rs
@@ -8,13 +8,15 @@ use rust_zserio::ztype::ZserioPackableObject;
 pub fn test_ambiguous_types() {
     // Create a test structure, and assign a new instance.
     // If this line compiles, the test passes.
-    let mut test_struct1 = InstantiatedStruct1::new();
-    test_struct1.value_1 = 16;
-    test_struct1.value_2 = "test".into();
+    let test_struct1 = InstantiatedStruct1 {
+        value_1: 16,
+        value_2: "test".into(),
+    };
 
-    let mut test_struct2 = InstantiatedStruct2::new();
-    test_struct2.value_1 = "test".into();
-    test_struct2.value_2 = 22;
+    let test_struct2 = InstantiatedStruct2 {
+        value_1: "test".into(),
+        value_2: 22,
+    };
 
     let mut bitwriter = BitWriter::new();
     test_struct1

--- a/tests/round-trip-tests/src/type_casts_test.rs
+++ b/tests/round-trip-tests/src/type_casts_test.rs
@@ -1,11 +1,9 @@
 use reference_module_lib::reference_modules::type_casts::type_casts::type_cast_struct::TypeCastStruct;
 
-use rust_zserio::ztype::ZserioPackableObject;
-
 pub fn test_type_casts() {
     // The test structure created in this test generates a function that
     // requires a lot of type casts.
     // The test passes if the generated structure compiles.
-    let test_struct = TypeCastStruct::new();
+    let test_struct = TypeCastStruct::default();
     test_struct.test_type_casts();
 }


### PR DESCRIPTION
Now that all zserio types implement Default, we can remove the `new()` function from `ZserioPackableObject` and use trait inheritance to require a Default implementation.

This removes a useless function the generated code (which the compiler hopefully already optimized away). On a large zserio project such as NDS.Live this removes about 20k lines of generated code.
