### PR TITLE
Reduce cli verbosity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,15 @@ license = "BSD-3-Clause"
 [dependencies]
 antlr-rust = "0.3.0-beta"
 bitmask-enum = "2.2.4"
-bitreader =  "0.3.8"
+bitreader = "0.3.8"
 bitstream-io = "1.6.0"
-clap = { version="4.2.7", features = [ "derive" ] }
+clap = { version = "4.2.7", features = ["derive"] }
 codegen = "0.2.0"
 convert_case = "0.6.0"
 duplicate = "1.0.0"
 half = "2.3.1"
 itertools = "0.11.0"
+log = "0.4.22"
 num = "0.4.0"
 proc-macro2 = "1.0.66"
 rstest = "0.16.0"
@@ -41,3 +42,8 @@ rust-bitwriter = "0.0.1"
 rustfmt-wrapper = "0.2.1"
 thiserror = "1.0.61"
 walkdir = "2.3.2"
+
+[dependencies.simple_logger]
+version = "5.0.0"
+default-features = false
+features = ["colors", "stderr"]

--- a/src/internal/generator/file_generator.rs
+++ b/src/internal/generator/file_generator.rs
@@ -1,4 +1,5 @@
 use crate::internal::generator::types::TypeGenerator;
+use log::trace;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -28,7 +29,7 @@ pub fn write_to_file(
     }
     fs::create_dir_all(file_path.as_path()).expect("mkdir failed");
     let full_path = file_path.join(String::from(file_name) + ".rs");
-    println!("Writing file  {}", full_path.to_str().unwrap());
+    trace!("Writing file  {}", full_path.to_str().unwrap());
     let mut file_ref = std::fs::File::create(full_path).expect("create failed");
     file_ref.write_all(file_bytes).expect("write failed");
     file_ref.flush().expect("can not flush data to disk");

--- a/src/internal/generator/model.rs
+++ b/src/internal/generator/model.rs
@@ -1,8 +1,8 @@
 use crate::internal::generator::mod_file::generate_top_level_mod_file;
 use crate::internal::generator::package::generate_package;
 use crate::internal::generator::types::TypeGenerator;
-
 use crate::internal::model::Model;
+use log::info;
 use std::path::Path;
 
 pub fn generate_model(model: &mut Model, package_directory: &Path, root_package: &str) {
@@ -11,7 +11,7 @@ pub fn generate_model(model: &mut Model, package_directory: &Path, root_package:
     let scope = &mut model.scope;
     // Generate the rust interface files for all packages.
     for package in model.packages.values() {
-        println!("generating rust code for package {0}...", package.name);
+        info!("generating rust code for package {0}...", package.name);
         generate_package(&mut type_generator, scope, package, package_directory);
     }
 

--- a/src/internal/parser/gen.rs
+++ b/src/internal/parser/gen.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod zseriolexer;
 pub mod zserioparser;
 pub mod zserioparserlistener;

--- a/src/internal/parser/gen/error.rs
+++ b/src/internal/parser/gen/error.rs
@@ -1,0 +1,22 @@
+use antlr_rust::error_listener::ErrorListener;
+use antlr_rust::errors::ANTLRError;
+use antlr_rust::recognizer::Recognizer;
+use antlr_rust::token_factory::TokenFactory;
+use log::trace;
+
+#[derive(Debug)]
+pub struct LogErrorListener {}
+
+impl<'a, T: Recognizer<'a>> ErrorListener<'a, T> for LogErrorListener {
+    fn syntax_error(
+        &self,
+        _recognizer: &T,
+        _offending_symbol: Option<&<T::TF as TokenFactory<'a>>::Inner>,
+        line: isize,
+        column: isize,
+        msg: &str,
+        _e: Option<&ANTLRError>,
+    ) {
+        trace!("line {}:{} {}", line, column, msg);
+    }
+}

--- a/src/internal/parser/gen/zserioparser.rs
+++ b/src/internal/parser/gen/zserioparser.rs
@@ -582,14 +582,17 @@ where
             _decision_to_DFA.clone(),
             _shared_context_cache.clone(),
         ));
+        let mut base = BaseParser::new_base_parser(
+            input,
+            Arc::clone(&interpreter),
+            ZserioParserExt {
+                _pd: Default::default(),
+            },
+        );
+        base.remove_error_listeners();
+        base.add_error_listener(Box::new(super::error::LogErrorListener {}));
         Self {
-            base: BaseParser::new_base_parser(
-                input,
-                Arc::clone(&interpreter),
-                ZserioParserExt {
-                    _pd: Default::default(),
-                },
-            ),
+            base,
             interpreter,
             _shared_context_cache: Box::new(PredictionContextCache::new()),
             err_handler: strategy,

--- a/src/internal/parser/generate.sh
+++ b/src/internal/parser/generate.sh
@@ -1,1 +1,35 @@
+#!/bin/sh
+
 java -jar antlr-rust.jar -Dlanguage=Rust -visitor -o gen ZserioLexer.g4 ZserioParser.g4
+
+cat <<EOF
+Do not forget to udpate zserparsers.rs: you need to replace
+ZserioParser::with_strategy with something that looks like this:
+
+    pub fn with_strategy(input: I, strategy: H) -> Self {
+        antlr_rust::recognizer::check_version("0", "3");
+        let interpreter = Arc::new(ParserATNSimulator::new(
+            _ATN.clone(),
+            _decision_to_DFA.clone(),
+            _shared_context_cache.clone(),
+        ));
+        let mut base = BaseParser::new_base_parser(
+            input,
+            Arc::clone(&interpreter),
+            ZserioParserExt {
+                _pd: Default::default(),
+            },
+        );
+        base.remove_error_listeners();
+        base.add_error_listener(Box::new(super::error::LogErrorListener {}));
+        Self {
+            base,
+            interpreter,
+            _shared_context_cache: Box::new(PredictionContextCache::new()),
+            err_handler: strategy,
+        }
+    }
+
+This is required to change the error listener to something that does
+not spam the user with useless output.
+EOF

--- a/src/internal/visitor.rs
+++ b/src/internal/visitor.rs
@@ -64,7 +64,7 @@ use crate::internal::parser::gen::zserioparser::{
 use antlr_rust::parser_rule_context::ParserRuleContext;
 use antlr_rust::token::Token;
 use antlr_rust::tree::{ParseTree, ParseTreeVisitorCompat, TerminalNode, Tree};
-
+use log::{debug, info, trace, warn};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -147,10 +147,10 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
         let mut package_name = "".into();
         match self.visit(&*ctx.packageNameDefinition().unwrap()) {
             ZserioTreeReturnType::Str(n) => package_name = n,
-            _ => println!("package declaration missing"),
+            _ => warn!("package declaration missing"),
         }
 
-        println!("package found with name {package_name}");
+        info!("package found with name {package_name}");
 
         let mut imports = Vec::new();
         for import in ctx.importDeclaration_all() {
@@ -177,7 +177,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
 
         for directive in ctx.languageDirective_all() {
             match self.visit(&*directive) {
-                ZserioTreeReturnType::Str(s) => println!("unknown: {0}", s),
+                ZserioTreeReturnType::Str(s) => warn!("unknown package directive: {0}", s),
                 ZserioTreeReturnType::Vec(v) => {
                     for ve in v {
                         match ve {
@@ -207,13 +207,13 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
                                 .push(Rc::new(RefCell::new(*bitmask_type))),
                             ZserioTreeReturnType::Str(_) => {}
                             ZserioTreeReturnType::StrVec(s) => {
-                                println!("unknown str vec: {0}", s[0])
+                                warn!("unknown str vec: {0}", s[0])
                             }
                             ZserioTreeReturnType::TypeReference(z) => {
-                                println!("unknown type ref: {0}", z.bits)
+                                debug!("unknown type ref: {0}", z.bits)
                             }
-                            ZserioTreeReturnType::Field(_z) => print!("field found"),
-                            ZserioTreeReturnType::Expression(_e) => print!("expression found"),
+                            ZserioTreeReturnType::Field(_z) => trace!("field found"),
+                            ZserioTreeReturnType::Expression(_e) => trace!("expression found"),
                             ZserioTreeReturnType::InstantiateType(t) => {
                                 package.instantiated_types.push(Rc::new(RefCell::new(*t)))
                             }
@@ -529,7 +529,7 @@ impl ZserioParserVisitorCompat<'_> for Visitor {
         if let Some(x) = ctx.templateParameters() {
             match ZserioParserVisitorCompat::visit_templateParameters(self, &x) {
                 ZserioTreeReturnType::StrVec(n) => choice.template_parameters = n,
-                _ => println!("template parameters should be a list of strings"),
+                _ => warn!("template parameters should be a list of strings"),
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,18 @@
 use clap::Parser;
+use log::LevelFilter;
 use rust_zserio::internal::generator::model::generate_model;
 use rust_zserio::internal::model::Model;
+use simple_logger::SimpleLogger;
 use std::path::Path;
 
 /// zserio generator for rust.
 #[derive(Parser, Debug)]
 #[command(version = None)]
 struct Args {
+    /// Output verbosity
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
     /// Directory where to generate the zserio interface files.
     #[arg(short, long)]
     out: String,
@@ -21,6 +27,17 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
+
+    SimpleLogger::new()
+        .with_level(match args.verbose {
+            0 => LevelFilter::Warn,
+            1 => LevelFilter::Info,
+            2 => LevelFilter::Debug,
+            3.. => LevelFilter::Trace,
+        })
+        .init()
+        .expect("can not initialize logger");
+
     // Load the zserio files (*.zs) from the filesystem.
     let mut model = Model::from_filesystem(Path::new(args.zserio_path.as_str()));
 


### PR DESCRIPTION
The rust-zserio cli is extremely verbose: it outputs a ton of warnings from the ANTLR parser, as well as outputing a bunch of things itself. Most of the time this output is not useful for people and just creates noise. To deal with that this PR adds a basic logging setup to the cli, and uses the log crate to output at sensible log levels. By default only warnings (and errors) are logged. With this change we can convert the NDS.Live schema with no output.
