### PR TITLE
Export zserio package content as rust crate

### DIFF
--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -42,5 +42,7 @@ impl ZserioPackableObject for DrinkOrder {
 
     fn zserio_create_packing_context(_: &mut PackingContextNode) {}
 
-    fn zserio_init_packing_context(&self, _: &mut PackingContextNode) {}
+    fn zserio_init_packing_context(&self, _: &mut PackingContextNode) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/internal/generator/encode.rs
+++ b/src/internal/generator/encode.rs
@@ -58,7 +58,7 @@ pub fn encode_type(
         } else if packed {
             // packed encoding
             function.line(format!(
-                "context_node.children[{}].context.as_mut().unwrap().write(&{}, writer, &{});",
+                "context_node.children[{}].context.as_mut().unwrap().write(&{}, writer, &{})?;",
                 field_index,
                 initialize_array_trait(scope, type_generator, fund_type),
                 field_name,

--- a/src/internal/generator/package.rs
+++ b/src/internal/generator/package.rs
@@ -142,8 +142,14 @@ pub fn generate_package(
     mod_file_content += "#![allow(clippy::all)]\n";
     mod_file_content += "#![allow(warnings)]\n";
 
-    for module_name in module_names {
-        mod_file_content += format!("pub mod {};\n", module_name).as_str();
+    // Sort module names so our output is in a predictable order.
+    module_names.sort_unstable();
+    for module_name in &module_names {
+        mod_file_content += format!("pub mod {module_name};\n").as_str();
+    }
+
+    for module_name in &module_names {
+        mod_file_content += format!("pub use {module_name}::*;\n").as_str();
     }
 
     write_to_file(

--- a/src/internal/generator/packed_contexts.rs
+++ b/src/internal/generator/packed_contexts.rs
@@ -165,7 +165,7 @@ pub fn generate_init_packed_context_for_field(
 
     if field_details.native_type.is_marshaler {
         fn_gen.line(format!(
-            "{}.zserio_init_packing_context(&mut context_node.children[{}]);",
+            "{}.zserio_init_packing_context(&mut context_node.children[{}])?;",
             &field_name, field_details.field_index
         ));
     } else if field_details.is_packable {
@@ -175,7 +175,7 @@ pub fn generate_init_packed_context_for_field(
             field_details.field_context_node_name, field_details.field_index
         ));
         fn_gen.line(format!(
-            "{}_delta_context.init(&{}, &{});",
+            "{}_delta_context.init(&{}, &{})?;",
             &field_details.field_context_node_name,
             initialize_array_trait(
                 model_scope,

--- a/src/internal/generator/zbitmask.rs
+++ b/src/internal/generator/zbitmask.rs
@@ -76,8 +76,9 @@ pub fn generate_bitmask(
     let init_packing_context_fn = z_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     init_packing_context_fn.line(format!(
-        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(self.bits as {}));",
+        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(self.bits as {}))",
         &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &bitmask_rust_type,
     ));

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -100,6 +100,7 @@ pub fn generate_choice(
     let init_packing_context_fn = choice_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     for field in &field_details {
         generate_init_packed_context_for_field(
             symbol_scope,
@@ -108,6 +109,7 @@ pub fn generate_choice(
             field,
         );
     }
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -102,8 +102,9 @@ pub fn generate_enum(
     let init_packing_context_fn = z_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     init_packing_context_fn.line(format!(
-        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(*self as {}));",
+        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(*self as {}))",
         &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &rust_type_type,
     ));

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -98,6 +98,7 @@ pub fn generate_struct(
     let init_packing_context_fn = struct_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     for field in &field_details {
         generate_init_packed_context_for_field(
             symbol_scope,
@@ -106,6 +107,7 @@ pub fn generate_struct(
             field,
         );
     }
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions (defined in the zserio language).
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -131,6 +131,8 @@ pub fn generate_union(
     let init_packing_context_fn = union_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/ztype/array_traits/object_array_trait.rs
+++ b/src/ztype/array_traits/object_array_trait.rs
@@ -49,8 +49,7 @@ where
     }
 
     fn init_context(&self, context_node: &mut PackingContextNode, element: &T) -> Result<()> {
-        element.zserio_init_packing_context(context_node);
-        Ok(())
+        element.zserio_init_packing_context(context_node)
     }
 
     fn bitsize_of_packed(

--- a/src/ztype/traits.rs
+++ b/src/ztype/traits.rs
@@ -23,5 +23,5 @@ pub trait ZserioPackableObject: Default {
         bit_position: u64,
     ) -> Result<u64>;
     fn zserio_create_packing_context(context_node: &mut PackingContextNode);
-    fn zserio_init_packing_context(&self, context_node: &mut PackingContextNode);
+    fn zserio_init_packing_context(&self, context_node: &mut PackingContextNode) -> Result<()>;
 }

--- a/tests/compare-ref-impl-tests/rust/src/deserialize_artifacts.rs
+++ b/tests/compare-ref-impl-tests/rust/src/deserialize_artifacts.rs
@@ -76,7 +76,9 @@ pub fn compare_bitlength_calculations_with_python_reference<T: ZserioPackableObj
     // Calculate the packed bitsize
     let mut packing_context = PackingContextNode::new();
     T::zserio_create_packing_context(&mut packing_context);
-    zserio_object.zserio_init_packing_context(&mut packing_context);
+    zserio_object
+        .zserio_init_packing_context(&mut packing_context)
+        .unwrap();
     let actual_packed_bitsize = zserio_object
         .zserio_bitsize_packed(&mut packing_context, 0)
         .unwrap();

--- a/tests/round-trip-tests/src/alignment_test.rs
+++ b/tests/round-trip-tests/src/alignment_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::alignment::alignment::alignment_struct::AlignmentStruct;
+use reference_module_lib::reference_modules::alignment::alignment::AlignmentStruct;
 
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;

--- a/tests/round-trip-tests/src/ambiguous_types_test.rs
+++ b/tests/round-trip-tests/src/ambiguous_types_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::ambiguous_types::main::ambiguous_types_struct::AmbiguousTypesStruct;
+use reference_module_lib::reference_modules::ambiguous_types::main::AmbiguousTypesStruct;
 
 pub fn test_ambiguous_types() {
     // Create a test structure, and assign a new instance.

--- a/tests/round-trip-tests/src/bitmask_isset_test.rs
+++ b/tests/round-trip-tests/src/bitmask_isset_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::bitmask_isset::bitmask_isset::{
-    bitmask_test::BitmaskTest, some_bit_mask::SomeBitMask,
+    BitmaskTest, SomeBitMask,
 };
 
 use bitreader::BitReader;

--- a/tests/round-trip-tests/src/bitmask_test.rs
+++ b/tests/round-trip-tests/src/bitmask_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::bitmask_test::bitmask_test::{
-    bitmask_test::BitmaskTest, bitmask_with_zero::BitmaskWithZero, some_bit_mask::SomeBitMask,
+    BitmaskTest, BitmaskWithZero, SomeBitMask,
 };
 
 use rust_zserio::ztype::ZserioPackableObject;

--- a/tests/round-trip-tests/src/constants_test.rs
+++ b/tests/round-trip-tests/src/constants_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::constants::constants::constant_test_struct::ConstantTestStruct;
+use reference_module_lib::reference_modules::constants::constants::ConstantTestStruct;
 
 pub fn test_constants() {
     // The test structure created in this test generates a function that

--- a/tests/round-trip-tests/src/debug_trait_test.rs
+++ b/tests/round-trip-tests/src/debug_trait_test.rs
@@ -1,5 +1,5 @@
-use reference_module_lib::reference_modules::core::types::color::Color;
-use reference_module_lib::reference_modules::core::types::value_wrapper::ValueWrapper;
+use reference_module_lib::reference_modules::core::types::Color;
+use reference_module_lib::reference_modules::core::types::ValueWrapper;
 
 pub fn test_debug_trait() {
     let value_wrapper = ValueWrapper {

--- a/tests/round-trip-tests/src/expr_numbits_test.rs
+++ b/tests/round-trip-tests/src/expr_numbits_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::expr_numbits::expr_numbits::expression_numbits_test::ExpressionNumbitsTest;
+use reference_module_lib::reference_modules::expr_numbits::expr_numbits::ExpressionNumbitsTest;
 
 /// Tests a zserio struct, which uses a function with the numbits() operator.
 /// The function get_num_bits() is defined as `return numbits(u16Value) + numbits(8);`.

--- a/tests/round-trip-tests/src/integer_types_test.rs
+++ b/tests/round-trip-tests/src/integer_types_test.rs
@@ -1,5 +1,5 @@
 use bitreader::BitReader;
-use reference_module_lib::reference_modules::integer_types::integer_types::integer_types_test::IntegerTypesTest;
+use reference_module_lib::reference_modules::integer_types::integer_types::IntegerTypesTest;
 use rust_bitwriter::BitWriter;
 
 use rust_zserio::ztype::ZserioPackableObject;

--- a/tests/round-trip-tests/src/offsets_test.rs
+++ b/tests/round-trip-tests/src/offsets_test.rs
@@ -1,5 +1,5 @@
 use bitreader::BitReader;
-use reference_module_lib::reference_modules::offsets::offsets::offsets::Offsets;
+use reference_module_lib::reference_modules::offsets::offsets::Offsets;
 use rust_bitwriter::BitWriter;
 
 use rust_zserio::ztype::ZserioPackableObject;

--- a/tests/round-trip-tests/src/optional_values_test.rs
+++ b/tests/round-trip-tests/src/optional_values_test.rs
@@ -1,6 +1,6 @@
 use bitreader::BitReader;
 use reference_module_lib::reference_modules::optional_values::optional_values::{
-    option_enum::OptionEnum, optional_values_test::OptionalValuesTest,
+    OptionEnum, OptionalValuesTest,
 };
 use rust_bitwriter::BitWriter;
 

--- a/tests/round-trip-tests/src/packed_arrays_test.rs
+++ b/tests/round-trip-tests/src/packed_arrays_test.rs
@@ -1,7 +1,6 @@
 use bitreader::BitReader;
 use reference_module_lib::reference_modules::packed_arrays::packed_arrays::{
-    bubble_tea_addons::BubbleTeaAddons, bubble_tea_size::BubbleTeaSize, data_struct::DataStruct,
-    packed_array_wrapper::PackedArrayWrapper,
+    BubbleTeaAddons, BubbleTeaSize, DataStruct, PackedArrayWrapper,
 };
 use rust_bitwriter::BitWriter;
 use rust_zserio::ztype::array_traits::packing_context_node::PackingContextNode;

--- a/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_bitmask_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::parameter_passing_bitmask::parameter_passing_bitmask::{
-    item::Item, some_bit_mask::SomeBitMask, parameter_passing_bitmask::ParameterPassingBitmask
+    Item, SomeBitMask, ParameterPassingBitmask
 };
 
 use bitreader::BitReader;

--- a/tests/round-trip-tests/src/parameter_passing_templates_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_templates_test.rs
@@ -1,10 +1,10 @@
 use reference_module_lib::reference_modules::parameter_passing_templates::parameter_passing_templates::{
-    parameter_passing_templates::ParameterPassingTemplates,
-    templated_blockstring::TemplatedBlockstring,
-    templated_blockuint_64::TemplatedBlockuint64,
-    templated_choiceuint_32_string::TemplatedChoiceuint32String,
-    templated_unionuint_32_string::TemplatedUnionuint32String,
-    templated_unionuint_32_string::TemplatedUnionuint32StringSelector,
+    ParameterPassingTemplates,
+    TemplatedBlockstring,
+    TemplatedBlockuint64,
+    TemplatedChoiceuint32String,
+    TemplatedUnionuint32String,
+    TemplatedUnionuint32StringSelector,
 };
 
 use bitreader::BitReader;

--- a/tests/round-trip-tests/src/parameter_passing_test.rs
+++ b/tests/round-trip-tests/src/parameter_passing_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::parameter_passing::parameter_passing::{
-    block::Block, parameter_passing::ParameterPassing,
+    Block, ParameterPassing,
 };
 
 use bitreader::BitReader;

--- a/tests/round-trip-tests/src/parameterized_array_length_test.rs
+++ b/tests/round-trip-tests/src/parameterized_array_length_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::parameterized_array_length::parameterized_array_length::parameterized_array_length::ParameterizedArrayLength;
+use reference_module_lib::reference_modules::parameterized_array_length::parameterized_array_length::ParameterizedArrayLength;
 
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;

--- a/tests/round-trip-tests/src/subtyped_dot_expression.rs
+++ b/tests/round-trip-tests/src/subtyped_dot_expression.rs
@@ -1,5 +1,5 @@
-use reference_module_lib::reference_modules::subtyped_dot_expression::test::test_struct::TestStruct;
-use reference_module_lib::reference_modules::subtyped_dot_expression::subtyped_enum::subtyped_enum::SubtypedEnum;
+use reference_module_lib::reference_modules::subtyped_dot_expression::subtyped_enum::SubtypedEnum;
+use reference_module_lib::reference_modules::subtyped_dot_expression::test::TestStruct;
 
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;

--- a/tests/round-trip-tests/src/template_instantiation_test.rs
+++ b/tests/round-trip-tests/src/template_instantiation_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::template_instantiation::template_instantiation::{
-    instantiated_struct_1::InstantiatedStruct1, instantiated_struct_2::InstantiatedStruct2,
+    InstantiatedStruct1, InstantiatedStruct2,
 };
 use rust_bitwriter::BitWriter;
 

--- a/tests/round-trip-tests/src/type_casts_test.rs
+++ b/tests/round-trip-tests/src/type_casts_test.rs
@@ -1,4 +1,4 @@
-use reference_module_lib::reference_modules::type_casts::type_casts::type_cast_struct::TypeCastStruct;
+use reference_module_lib::reference_modules::type_casts::type_casts::TypeCastStruct;
 
 pub fn test_type_casts() {
     // The test structure created in this test generates a function that

--- a/tests/round-trip-tests/src/valueof_operator_test.rs
+++ b/tests/round-trip-tests/src/valueof_operator_test.rs
@@ -1,5 +1,5 @@
 use reference_module_lib::reference_modules::valueof_operator::valueof_operator::{
-    color::Color, option_enum::OptionEnum, other_enum::OtherEnum, value_of_test::ValueOfTest,
+    Color, OptionEnum, OtherEnum, ValueOfTest,
 };
 
 pub fn test_valueof_operator() {


### PR DESCRIPTION
rust-zserio creates a Rust module for every zserio type. This makes importing types vary repetitive: if you want to import `MyStruct` from package `acme.cogs.types` you would need to import `acme::cogs::types::mystruct::MyStruct`, which repeats the type name. This changeset simplifies that by direcly exposing all types at the package
level, so you can directly import `acme::cogs::types::MyStruct`.

In addition the `use mod` statements are now also sorted to stabilize the output.
