### PR TITLE
Handle errors in zserio_init_packing_context

### DIFF
--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -42,5 +42,7 @@ impl ZserioPackableObject for DrinkOrder {
 
     fn zserio_create_packing_context(_: &mut PackingContextNode) {}
 
-    fn zserio_init_packing_context(&self, _: &mut PackingContextNode) {}
+    fn zserio_init_packing_context(&self, _: &mut PackingContextNode) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/internal/generator/encode.rs
+++ b/src/internal/generator/encode.rs
@@ -58,7 +58,7 @@ pub fn encode_type(
         } else if packed {
             // packed encoding
             function.line(format!(
-                "context_node.children[{}].context.as_mut().unwrap().write(&{}, writer, &{});",
+                "context_node.children[{}].context.as_mut().unwrap().write(&{}, writer, &{})?;",
                 field_index,
                 initialize_array_trait(scope, type_generator, fund_type),
                 field_name,

--- a/src/internal/generator/packed_contexts.rs
+++ b/src/internal/generator/packed_contexts.rs
@@ -165,7 +165,7 @@ pub fn generate_init_packed_context_for_field(
 
     if field_details.native_type.is_marshaler {
         fn_gen.line(format!(
-            "{}.zserio_init_packing_context(&mut context_node.children[{}]);",
+            "{}.zserio_init_packing_context(&mut context_node.children[{}])?;",
             &field_name, field_details.field_index
         ));
     } else if field_details.is_packable {
@@ -175,7 +175,7 @@ pub fn generate_init_packed_context_for_field(
             field_details.field_context_node_name, field_details.field_index
         ));
         fn_gen.line(format!(
-            "{}_delta_context.init(&{}, &{});",
+            "{}_delta_context.init(&{}, &{})?;",
             &field_details.field_context_node_name,
             initialize_array_trait(
                 model_scope,

--- a/src/internal/generator/zbitmask.rs
+++ b/src/internal/generator/zbitmask.rs
@@ -76,8 +76,9 @@ pub fn generate_bitmask(
     let init_packing_context_fn = z_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     init_packing_context_fn.line(format!(
-        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(self.bits as {}));",
+        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(self.bits as {}))",
         &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &bitmask_rust_type,
     ));

--- a/src/internal/generator/zchoice.rs
+++ b/src/internal/generator/zchoice.rs
@@ -100,6 +100,7 @@ pub fn generate_choice(
     let init_packing_context_fn = choice_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     for field in &field_details {
         generate_init_packed_context_for_field(
             symbol_scope,
@@ -108,6 +109,7 @@ pub fn generate_choice(
             field,
         );
     }
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/internal/generator/zenum.rs
+++ b/src/internal/generator/zenum.rs
@@ -102,8 +102,9 @@ pub fn generate_enum(
     let init_packing_context_fn = z_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     init_packing_context_fn.line(format!(
-        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(*self as {}));",
+        "context_node.children[0].context.as_mut().unwrap().init(&{}, &(*self as {}))",
         &initialize_array_trait(scope, type_generator, &fundamental_type.fundamental_type),
         &rust_type_type,
     ));

--- a/src/internal/generator/zstruct.rs
+++ b/src/internal/generator/zstruct.rs
@@ -98,6 +98,7 @@ pub fn generate_struct(
     let init_packing_context_fn = struct_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
     for field in &field_details {
         generate_init_packed_context_for_field(
             symbol_scope,
@@ -106,6 +107,7 @@ pub fn generate_struct(
             field,
         );
     }
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions (defined in the zserio language).
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/internal/generator/zunion.rs
+++ b/src/internal/generator/zunion.rs
@@ -131,6 +131,8 @@ pub fn generate_union(
     let init_packing_context_fn = union_impl.new_fn("zserio_init_packing_context");
     init_packing_context_fn.arg_ref_self();
     init_packing_context_fn.arg("context_node", "&mut PackingContextNode");
+    init_packing_context_fn.ret("Result<()>");
+    init_packing_context_fn.line("Ok(())");
 
     // Generate all the zserio functions.
     let pub_impl = codegen_scope.new_impl(&rust_type_name);

--- a/src/ztype/array_traits/object_array_trait.rs
+++ b/src/ztype/array_traits/object_array_trait.rs
@@ -49,8 +49,7 @@ where
     }
 
     fn init_context(&self, context_node: &mut PackingContextNode, element: &T) -> Result<()> {
-        element.zserio_init_packing_context(context_node);
-        Ok(())
+        element.zserio_init_packing_context(context_node)
     }
 
     fn bitsize_of_packed(

--- a/src/ztype/traits.rs
+++ b/src/ztype/traits.rs
@@ -23,5 +23,5 @@ pub trait ZserioPackableObject: Default {
         bit_position: u64,
     ) -> Result<u64>;
     fn zserio_create_packing_context(context_node: &mut PackingContextNode);
-    fn zserio_init_packing_context(&self, context_node: &mut PackingContextNode);
+    fn zserio_init_packing_context(&self, context_node: &mut PackingContextNode) -> Result<()>;
 }


### PR DESCRIPTION
clippy was complaining we were ignoring `Result` value returned inside generated `zserio_init_packing_context implementatations`. Fix that by making `zserio_init_packing_context` return `Result<()>` and handling all results properly.

* [ ] Test against NDS.Live
