### PR TITLE
Run CI for all pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Currently CI checks are only performed for pull requests that target `main`. Since it is not uncommon to stack pull requests enable CI for all pull requests.
