### PR TITLE
Add docs rust-zserio and zserio-rs-build

### DIFF
--- a/crates/rust-zserio/src/main.rs
+++ b/crates/rust-zserio/src/main.rs
@@ -1,3 +1,9 @@
+//! # rust-zserio is obsolete
+//! This package is obsolete, and should not be used. Please use the
+//! [zserio-rs-build](https://crates.io/crates/zserio-rs-build) package for the
+//! Rust zserio compiler, and [zserio](https://crates.io/crates/zserio) for the
+//! runtime support code.
+
 use cargo_util::ProcessBuilder;
 use std::env;
 

--- a/crates/zserio-rs-build/src/lib.rs
+++ b/crates/zserio-rs-build/src/lib.rs
@@ -1,3 +1,15 @@
+//! This package provides a compiler to Generate rust code for the [zserio](http://zserio.org/)
+//! serialization formst. `zserio` is a binary serialization language, similar to Protobuf. The key
+//! features are:
+//!
+//! - It features a rich schema.
+//! - Programming language agnostic.
+//! - Compact and easy to use.
+//! - Good and fast out-of the box compression.
+//!
+//! The syntax is similar to C/C++, which makes zserio code easy to read.
+//!
+//! For more information on zserio in Rust please see [zserio](https://crates.io/crates/zserio).
 mod internal;
 
 pub use internal::generator::model::generate_model;

--- a/crates/zserio/src/lib.rs
+++ b/crates/zserio/src/lib.rs
@@ -1,5 +1,6 @@
-//! [zserio](http://zserio.org/) serialization bindings for rust. `zserio` is a
-//! binary serialization language, similar to Protobuf. The key features are:
+//! [zserio](http://zserio.org/) serialization bindings for rust. `zserio` is a binary
+//! serialization language, similar to Protobuf. The key features are:
+//!
 //! - It features a rich schema.
 //! - Programming language agnostic.
 //! - Compact and easy to use.
@@ -27,18 +28,19 @@
 //! Above code is `zserio` code. Using the `zserio` serialization bindings, this
 //! code can be used to generate C++/Python/Java code to read/write
 //! `zserio`-encoded data. With this crate, it is now possible to read/write
-//! `zserio`-encoded binary data in rust. To compile a `zs` file with
-//! rust-zserio, first install rust-zserio:
+//! `zserio`-encoded binary data in rust. To generate Rust code for a zserio schema
+//! you must first install `zserio-rs-build`:
 //!
 //! ```sh
-//! cargo install rust-zserio
+//! cargo install zserio-rs-build
 //! ```
 //!
 //! Afterwards, you can run the code generator:
 //!
 //! ```sh
-//! rust-zserio --root=<code_root_path> -o=<output_directory> <path_to_zserio_files>
+//! rust-rs-build --root=<code_root_path> -o=<output_directory> <path_to_zserio_files>
 //! ```
+//!
 //! This will generate the interface files in rust, that allow reading/writing
 //! zserio-encoded data.
 //!


### PR DESCRIPTION
The main documentation is in the zserio crate. The other crates
do deserve some minimal content to describe their purpose, and
link to the zserio crate.
