### PR TITLE
Update CI to release all packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,25 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Release using cargo publish
-      run: |
-        export VERSION=${{ github.ref_name }}
-        sed -i "s/0.0.0/${VERSION:1}/g" Cargo.toml
-        cat Cargo.toml
-        cargo publish --allow-dirty
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set version number
+        run: |
+          export VERSION=${{ github.ref_name }}
+          sed -i "s/0.0.0/${VERSION:1}/g" Cargo.toml
+
+      - name: Publish zserio
+        run: cargo publish --allow-dirty -p zserio
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish zserio-rs-build
+        run: cargo publish --allow-dirty -p zserio-rs-build
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish zserio
+        run: cargo publish --allow-dirty -p rust-zserio
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_zserio"
+name = "rust-zserio"
 version = "0.0.0"
 dependencies = [
  "cargo-util",

--- a/crates/rust-zserio/Cargo.toml
+++ b/crates/rust-zserio/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust_zserio"
+name = "rust-zserio"
 description = "[OBSELETE] Rust zserio support"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Since the root Cargo.toml no longer defines a package, we need to explicitly tell Cargo which package to publish.

This fixes the [release error for v0.3.0](https://github.com/Danaozhong/rust-zserio/actions/runs/10571811693/job/29288501226)
