### PR TITLE
Use cargo-release for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release rust-zserio crate
+name: Release packages
 
 on:
   push:
@@ -10,27 +10,37 @@ env:
 
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set version number
+      - name: Install cargo-release
+        run: cargo install cargo-release
+
+      - name: Determine version number
+        id: version
         run: |
-          export VERSION=${{ github.ref_name }}
-          sed -i "s/0.0.0/${VERSION:1}/g" Cargo.toml
+          version=${{ github.ref_name }}
+          echo "VERSION=${version:1}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish zserio
-        run: cargo publish --allow-dirty -p zserio
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Update version in Cargo.toml
+        run: |
+          echo "::group::Update version"
+          cargo release version --workspace --no-confirm -x ${{ steps.version.outputs.VERSION }}
+          echo "::endgroup::"
+          echo "::group::Configure git"
+          git config user.name github-actions[bot]
+          git config user.email github-actions@github.com
+          git checkout ${GITHUB_HEAD_REF#refs/heads/}
+          echo "::endgroup::"
+          echo "::group::Commit changes"
+          cargo release commit --no-confirm -x
+          echo "::endgroup::"
 
-      - name: Publish zserio-rs-build
-        run: cargo publish --allow-dirty -p zserio-rs-build
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish zserio
-        run: cargo publish --allow-dirty -p rust-zserio
+      - name: Publish packages
+        run: cargo release --workspace --allow-branch "*" --no-tag --no-push --no-confirm -x ${{ steps.version.outputs.VERSION }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/crates/zserio-rs-build/Cargo.toml
+++ b/crates/zserio-rs-build/Cargo.toml
@@ -26,7 +26,7 @@ prettyplease = "0.2.20"
 stringcase = "0.3.0"
 syn = "2.0.74"
 walkdir = "2.3.2"
-zserio = { path = "../zserio" }
+zserio = { version = "0.0.0", path = "../zserio" }
 
 [dependencies.simple_logger]
 version = "5.0.0"

--- a/crates/zserio-rs-build/Cargo.toml
+++ b/crates/zserio-rs-build/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 keywords.workspace = true
 categories = [
     "encoding",
-    "copmilers",
+    "compilers",
     "command-line-utilities",
     "development-tools::build-utils",
 ]

--- a/tests/compare-ref-impl-tests/rust/Cargo.toml
+++ b/tests/compare-ref-impl-tests/rust/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "compare-ref-impl-tests"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/reference-module-lib/Cargo.toml
+++ b/tests/reference-module-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reference-module-lib"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/round-trip-tests/Cargo.toml
+++ b/tests/round-trip-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "round-trip-tests"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
[cargo-release](https://github.com/crate-ci/cargo-release) will handle support for multiple packages, and updating the version of local dependencies correctly.
