### PR TITLE
Derive Eq and Hash for enums

### DIFF
--- a/crates/zserio-rs-build/src/internal/generator/zenum.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zenum.rs
@@ -34,7 +34,9 @@ pub fn generate_enum(
     gen_enum.derive("Default");
     gen_enum.derive("Clone");
     gen_enum.derive("Copy");
+    gen_enum.derive("Hash");
     gen_enum.derive("PartialEq");
+    gen_enum.derive("Eq");
 
     let mut enum_value = 0;
     let mut first_option = true;


### PR DESCRIPTION
This can be helpful if you want to use an enum as (part of) a key in a collection.

fixes #113
