### PR TITLE
Properly handle alignment errors

### DIFF
--- a/crates/zserio-rs-build/src/internal/generator/decode.rs
+++ b/crates/zserio-rs-build/src/internal/generator/decode.rs
@@ -134,7 +134,10 @@ pub fn decode_field(
 
     // Align the byte stream, if alignment is specified.
     if field.alignment != 0 {
-        function.line(format!("ztype::align_reader(reader, {});", field.alignment));
+        function.line(format!(
+            "ztype::align_reader(reader, {})?;",
+            field.alignment
+        ));
     }
 
     // Check if there is an offset set for this field.
@@ -150,7 +153,7 @@ pub fn decode_field(
         );
 
         if !use_indexed_offset {
-            function.line("ztype::align_reader(reader, 8);");
+            function.line("ztype::align_reader(reader, 8)?;");
         }
     }
 

--- a/crates/zserio-rs-build/src/internal/generator/encode.rs
+++ b/crates/zserio-rs-build/src/internal/generator/encode.rs
@@ -142,7 +142,10 @@ pub fn encode_field(
 
     // Align the byte stream, if alignment is specified.
     if field.alignment != 0 {
-        function.line(format!("ztype::align_writer(writer, {});", field.alignment));
+        function.line(format!(
+            "ztype::align_writer(writer, {})?;",
+            field.alignment
+        ));
     }
 
     // Check if there is an offset set for this field.
@@ -158,7 +161,7 @@ pub fn encode_field(
         );
 
         if !use_indexed_offset {
-            function.line("ztype::align_writer(writer, 8);".to_string());
+            function.line("ztype::align_writer(writer, 8)?;".to_string());
         }
     }
 

--- a/crates/zserio/src/ztype/alignment.rs
+++ b/crates/zserio/src/ztype/alignment.rs
@@ -1,18 +1,21 @@
+use crate::error::{Result, ZserioError};
 use bitreader::BitReader;
 use rust_bitwriter::BitWriter;
 
 /// Aligns the bit reader to a bit boundary, e.g. alignment_bits == 8 would align to the next
 /// byte boundary.
-pub fn align_reader(reader: &mut BitReader, u64_alignment_bits: u64) {
+pub fn align_reader(reader: &mut BitReader, u64_alignment_bits: u64) -> Result<()> {
     let cur_alignment = reader.position() % u64_alignment_bits;
     let bits_to_skip = (u64_alignment_bits - cur_alignment) % u64_alignment_bits;
-    reader.skip(bits_to_skip).expect("failed to align reader");
+    reader.skip(bits_to_skip)?;
+    Ok(())
 }
 
-pub fn align_writer(writer: &mut BitWriter, u64_alignment_bits: u64) {
+pub fn align_writer(writer: &mut BitWriter, u64_alignment_bits: u64) -> Result<()> {
     let cur_alignment = writer.bit_count() % u64_alignment_bits;
     let bits_to_skip = (u64_alignment_bits - cur_alignment) % u64_alignment_bits;
-    writer.skip(bits_to_skip).expect("failed to align writer");
+    writer.skip(bits_to_skip)?;
+    Ok(())
 }
 
 pub fn align_bitsize(bit_pos: u64, u64_alignment_bits: u64) -> u64 {

--- a/crates/zserio/src/ztype/array.rs
+++ b/crates/zserio/src/ztype/array.rs
@@ -52,13 +52,13 @@ impl<T> Array<T> {
 
             // Actually write the data.
             for (index, element) in data.iter().enumerate() {
-                align_array_element_writer(writer, index, index_offsets);
+                align_array_element_writer(writer, index, index_offsets)?;
                 self.array_trait
                     .write_packed(&mut packing_context_node, writer, element)?;
             }
         } else {
             for (index, element) in data.iter().enumerate() {
-                align_array_element_writer(writer, index, index_offsets);
+                align_array_element_writer(writer, index, index_offsets)?;
                 self.array_trait.write(writer, element)?;
             }
         }
@@ -83,7 +83,7 @@ impl<T> Array<T> {
                 // Create the packing context, and all child-contexts
                 let mut packing_context_node = self.array_trait.create_context();
                 for (index, data_item) in data.iter_mut().enumerate() {
-                    align_array_element_reader(reader, index, index_offsets);
+                    align_array_element_reader(reader, index, index_offsets)?;
                     self.array_trait.read_packed(
                         &mut packing_context_node,
                         reader,
@@ -93,7 +93,7 @@ impl<T> Array<T> {
                 }
             } else {
                 for (index, data_item) in data.iter_mut().enumerate() {
-                    align_array_element_reader(reader, index, index_offsets);
+                    align_array_element_reader(reader, index, index_offsets)?;
                     self.array_trait.read(reader, data_item, index)?;
                 }
             }
@@ -187,21 +187,23 @@ fn align_array_element_writer<T: OffsetTrait>(
     writer: &mut BitWriter,
     _index: usize,
     index_offsets: Option<&Vec<T>>,
-) {
+) -> Result<()> {
     // A small helper function to byte-align each array element, if desired, during writing.
     if index_offsets.is_some() {
-        align_writer(writer, 8);
+        align_writer(writer, 8)?;
     }
+    Ok(())
 }
 fn align_array_element_reader<T: OffsetTrait>(
     reader: &mut BitReader,
     _index: usize,
     index_offsets: Option<&Vec<T>>,
-) {
+) -> Result<()> {
     // A small helper function to byte-align each array element, if desired, during reading.
     if index_offsets.is_some() {
-        align_reader(reader, 8);
+        align_reader(reader, 8)?;
     }
+    Ok(())
 }
 
 fn align_array_element_bitsize<T: OffsetTrait>(


### PR DESCRIPTION
Instead of panicing we should do the right thing and return an error.
