### PR TITLE
Fix rust-zserio backwards compat cli

### DIFF
--- a/crates/rust-zserio/src/main.rs
+++ b/crates/rust-zserio/src/main.rs
@@ -10,13 +10,13 @@ use std::env;
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    if ProcessBuilder::new("zserio-cli")
+    if ProcessBuilder::new("zserio-rs-build")
         .args_replace(&args)
         .exec_replace()
         .is_err()
     {
-        eprintln!("Can not run zserio-cli. Please make sure you have installed it.");
+        eprintln!("Can not run zserio-rs-build. Please make sure you have installed it.");
         eprintln!();
-        eprintln!("    cargo install zserio-cli");
+        eprintln!("    cargo install zserio-rs-build");
     }
 }


### PR DESCRIPTION
This was still using an older name for `zserio-rs-build`.
