### PR TITLE
Drop caches in TypeGenerator

### DIFF
--- a/crates/zserio-rs-build/src/internal/generator/decode.rs
+++ b/crates/zserio-rs-build/src/internal/generator/decode.rs
@@ -242,7 +242,7 @@ pub fn decode_field(
 
             function.line(format!(
                 "{}: {},",
-                type_generator.convert_field_name(&type_parameter.borrow().name),
+                TypeGenerator::convert_field_name(&type_parameter.borrow().name),
                 rvalue,
             ));
             fields_remaining -= 1;
@@ -317,7 +317,7 @@ pub fn decode_field(
 
             function.line(format!(
                 "element.{} = {};",
-                type_generator.convert_field_name(&type_parameter.borrow().name),
+                TypeGenerator::convert_field_name(&type_parameter.borrow().name),
                 rvalue,
             ));
         }
@@ -350,7 +350,7 @@ pub fn decode_field(
     if field.is_optional {
         function.line(format!(
             "self.{} = Option::from(optional_value);",
-            type_generator.convert_field_name(&field.name)
+            TypeGenerator::convert_field_name(&field.name)
         ));
         function.line("}"); // close the "if present {"
     }

--- a/crates/zserio-rs-build/src/internal/generator/encode.rs
+++ b/crates/zserio-rs-build/src/internal/generator/encode.rs
@@ -255,7 +255,7 @@ pub fn encode_field(
             function.line(format!(
                 "assert!({}.{} == {});",
                 &element_name,
-                type_generator.convert_field_name(&type_parameter.borrow().name),
+                TypeGenerator::convert_field_name(&type_parameter.borrow().name),
                 rvalue,
             ));
         }

--- a/crates/zserio-rs-build/src/internal/generator/expression.rs
+++ b/crates/zserio-rs-build/src/internal/generator/expression.rs
@@ -208,7 +208,7 @@ fn generate_dot_expression(
             let expr_symbol = op1.symbol.as_ref().unwrap();
             let enum_expression = format!(
                 "{}::{}",
-                type_generator.custom_type_to_rust_type(&expr_symbol.name),
+                TypeGenerator::custom_type_to_rust_type(&expr_symbol.name),
                 convert_to_enum_field_name(&op2.text)
             );
             type_generator.get_full_module_path(&expr_symbol.package, &enum_expression)
@@ -217,7 +217,7 @@ fn generate_dot_expression(
             let bitmask_symbol = op1.symbol.as_ref().unwrap();
             let bitmask_expression = format!(
                 "{}::{}",
-                type_generator.custom_type_to_rust_type(&bitmask_symbol.name),
+                TypeGenerator::custom_type_to_rust_type(&bitmask_symbol.name),
                 convert_to_enum_field_name(&op2.text)
             );
             type_generator.get_full_module_path(&bitmask_symbol.package, &bitmask_expression)
@@ -226,7 +226,7 @@ fn generate_dot_expression(
             let left_operand = generate_expression(op1, type_generator, scope);
             let right_side = match op2.flag {
                 ExpressionFlag::IsDotExpressionRightOperand => {
-                    type_generator.convert_field_name(&op2.text)
+                    TypeGenerator::convert_field_name(&op2.text)
                 }
                 _ => panic!("failed to generate right side of field dot expression"),
             };
@@ -302,31 +302,31 @@ fn generate_identifier_expression(
         Symbol::Field(f) => {
             return format!(
                 "self.{}",
-                type_generator.convert_field_name(&f.borrow().name),
+                TypeGenerator::convert_field_name(&f.borrow().name),
             );
         }
         Symbol::Parameter(p) => {
             return format!(
                 "self.{}",
-                type_generator.convert_field_name(&p.borrow().name)
+                TypeGenerator::convert_field_name(&p.borrow().name)
             )
         }
         Symbol::Function(z_function) => {
             return format!(
                 "self.{}",
-                type_generator.convert_field_name(&z_function.borrow().name)
+                TypeGenerator::convert_field_name(&z_function.borrow().name)
             )
         }
         _ => (),
     }
 
     let rust_symbol_name = match &symbol_ref.symbol {
-        Symbol::Struct(s) => type_generator.custom_type_to_rust_type(&s.borrow().name),
-        Symbol::Choice(c) => type_generator.custom_type_to_rust_type(&c.borrow().name),
-        Symbol::Union(u) => type_generator.custom_type_to_rust_type(&u.borrow().name),
-        Symbol::Enum(e) => type_generator.custom_type_to_rust_type(&e.borrow().name),
-        Symbol::Bitmask(bitmask) => type_generator.custom_type_to_rust_type(&bitmask.borrow().name),
-        Symbol::Const(zconst) => type_generator.constant_type_to_rust_type(&zconst.borrow().name),
+        Symbol::Struct(s) => TypeGenerator::custom_type_to_rust_type(&s.borrow().name),
+        Symbol::Choice(c) => TypeGenerator::custom_type_to_rust_type(&c.borrow().name),
+        Symbol::Union(u) => TypeGenerator::custom_type_to_rust_type(&u.borrow().name),
+        Symbol::Enum(e) => TypeGenerator::custom_type_to_rust_type(&e.borrow().name),
+        Symbol::Bitmask(bitmask) => TypeGenerator::custom_type_to_rust_type(&bitmask.borrow().name),
+        Symbol::Const(zconst) => TypeGenerator::constant_type_to_rust_type(&zconst.borrow().name),
         _ => panic!("unsupported identifier type {:?}", expression.symbol),
     };
     type_generator.get_full_module_path(&symbol_ref.package, &rust_symbol_name)

--- a/crates/zserio-rs-build/src/internal/generator/file_generator.rs
+++ b/crates/zserio-rs-build/src/internal/generator/file_generator.rs
@@ -4,19 +4,13 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-pub fn write_to_file(
-    type_generator: &mut TypeGenerator,
-    content: &str,
-    root_path: &Path,
-    zserio_pkg_name: &str,
-    file_name: &str,
-) {
+pub fn write_to_file(content: &str, root_path: &Path, zserio_pkg_name: &str, file_name: &str) {
     let syntax_tree = syn::parse_str(content).expect("can not parse code");
     let formatted_code = prettyplease::unparse(&syntax_tree);
 
     let mut file_path = root_path.to_owned();
     for dir in String::from(zserio_pkg_name).split('.') {
-        file_path = file_path.join(type_generator.to_rust_module_name(dir));
+        file_path = file_path.join(TypeGenerator::to_rust_module_name(dir));
     }
     fs::create_dir_all(file_path.as_path()).expect("mkdir failed");
     let full_path = file_path.join(String::from(file_name) + ".rs");

--- a/crates/zserio-rs-build/src/internal/generator/mod_file.rs
+++ b/crates/zserio-rs-build/src/internal/generator/mod_file.rs
@@ -11,15 +11,11 @@ struct ZserioModuleTreeNode {
     children: HashMap<String, Rc<RefCell<ZserioModuleTreeNode>>>,
 }
 
-fn add_package_to_tree(
-    type_generator: &mut TypeGenerator,
-    tree_node: &Rc<RefCell<ZserioModuleTreeNode>>,
-    pkg_name: &str,
-) {
+fn add_package_to_tree(tree_node: &Rc<RefCell<ZserioModuleTreeNode>>, pkg_name: &str) {
     let mut current_node: Rc<RefCell<ZserioModuleTreeNode>> = tree_node.clone();
     //let mut current_node = tree_node;
     for module_path in pkg_name.split('.') {
-        let rust_module_name = type_generator.to_rust_module_name(module_path);
+        let rust_module_name = TypeGenerator::to_rust_module_name(module_path);
 
         if let Some(child_node) = current_node
             .clone()
@@ -78,19 +74,14 @@ fn generate_mod_section(
 
 /// This function generates the top-level mod file, which adds all generated packages
 /// to the known packages.
-pub fn generate_top_level_mod_file(
-    type_generator: &mut TypeGenerator,
-    model: &Model,
-    package_directory: &Path,
-    root_package: &str,
-) {
+pub fn generate_top_level_mod_file(model: &Model, package_directory: &Path, root_package: &str) {
     // Reorganize the packages into a tree structure, categorized by module.
     let module_tree_root = Rc::from(RefCell::from(ZserioModuleTreeNode {
         children: HashMap::new(),
     }));
 
     for package in model.packages.values() {
-        add_package_to_tree(type_generator, &module_tree_root, &package.name);
+        add_package_to_tree(&module_tree_root, &package.name);
     }
 
     // Generate the mod.rs file content.
@@ -105,11 +96,5 @@ pub fn generate_top_level_mod_file(
         filename = "lib";
     }
 
-    write_to_file(
-        type_generator,
-        &mod_file_content,
-        package_directory,
-        "",
-        filename,
-    );
+    write_to_file(&mod_file_content, package_directory, "", filename);
 }

--- a/crates/zserio-rs-build/src/internal/generator/model.rs
+++ b/crates/zserio-rs-build/src/internal/generator/model.rs
@@ -16,5 +16,5 @@ pub fn generate_model(model: &mut Model, package_directory: &Path, root_package:
     }
 
     // Generate the overall mod file.
-    generate_top_level_mod_file(&mut type_generator, model, package_directory, root_package);
+    generate_top_level_mod_file(model, package_directory, root_package);
 }

--- a/crates/zserio-rs-build/src/internal/generator/package.rs
+++ b/crates/zserio-rs-build/src/internal/generator/package.rs
@@ -170,11 +170,5 @@ pub fn generate_package(
         mod_file_content += format!("pub use {module_name}::*;\n").as_str();
     }
 
-    write_to_file(
-        type_generator,
-        &mod_file_content,
-        package_directory,
-        package_name,
-        "mod",
-    );
+    write_to_file(&mod_file_content, package_directory, package_name, "mod");
 }

--- a/crates/zserio-rs-build/src/internal/generator/packed_contexts.rs
+++ b/crates/zserio-rs-build/src/internal/generator/packed_contexts.rs
@@ -32,7 +32,7 @@ impl FieldDetails {
         type_generator: &mut TypeGenerator,
     ) -> Self {
         let field = &field_rc.borrow();
-        let field_name = type_generator.convert_field_name(&field.name);
+        let field_name = TypeGenerator::convert_field_name(&field.name);
         let field_context_node_name = format!("field_{}_node", &field_name);
 
         // confirm if the field can be packed. even in packed mode, some fields

--- a/crates/zserio-rs-build/src/internal/generator/subtype.rs
+++ b/crates/zserio-rs-build/src/internal/generator/subtype.rs
@@ -14,15 +14,14 @@ pub fn generate_subtype(
 ) -> String {
     add_standard_imports(codegen_scope);
 
-    let rust_module_name = type_generator.to_rust_module_name(&subtype.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&subtype.name);
     let type_alias_scope = codegen_scope.new_type_alias(
-        type_generator.to_rust_type_name(&subtype.name),
+        TypeGenerator::to_rust_type_name(&subtype.name),
         type_generator.ztype_to_rust_type(&subtype.zserio_type),
     );
     type_alias_scope.vis("pub");
 
     write_to_file(
-        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,

--- a/crates/zserio-rs-build/src/internal/generator/types.rs
+++ b/crates/zserio-rs-build/src/internal/generator/types.rs
@@ -1,77 +1,47 @@
 use crate::internal::ast::type_reference::TypeReference;
-use std::{collections::HashMap, result::Result};
 use stringcase::Caser;
 
 const RESERVED_RUST_KEYWORDS: &[&str] = &["type", "struct", "self"];
 
 pub struct TypeGenerator {
     pub root_package_name: String,
-
-    // rust is super-slow in converting strings (e.g.
-    // upper/lower/camel/snake case), we keep track of
-    // all conversions already done, and simply reuse them
-    package_convert_cache: HashMap<String, String>,
-    field_name_cache: HashMap<String, String>,
-    module_name_cache: HashMap<String, String>,
-    type_name_cache: HashMap<String, String>,
 }
 
 impl TypeGenerator {
     pub fn new(root_package_name: String) -> Self {
-        Self {
-            root_package_name,
-            package_convert_cache: HashMap::new(),
-            field_name_cache: HashMap::new(),
-            module_name_cache: HashMap::new(),
-            type_name_cache: HashMap::new(),
-        }
+        Self { root_package_name }
     }
 
     pub fn zserio_package_to_rust_module(&mut self, package: &str) -> String {
         assert!(!package.is_empty(), "package type has not been resolved");
-
-        // Try to read from cache, if it already exists
-        if let Some(converted_package) = self.package_convert_cache.get(package) {
-            return converted_package.clone();
-        }
 
         let mut root_package = String::from("crate");
         if !self.root_package_name.is_empty() {
             root_package = format!("crate::{}", &self.root_package_name);
         }
         for module in package.split('.') {
-            root_package = format!("{}::{}", root_package, self.to_rust_module_name(module));
+            root_package = format!("{}::{}", root_package, Self::to_rust_module_name(module));
         }
-        // Keep the converted string in cache
-        self.package_convert_cache
-            .insert(package.to_owned(), root_package.clone());
         root_package
     }
 
-    pub fn convert_field_name(&mut self, name: &str) -> String {
-        if let Some(converted_field_name) = self.field_name_cache.get(name) {
-            return converted_field_name.clone();
-        }
-        let converted_field_name =
-            remove_reserved_identifier(name).to_snake_case_with_nums_as_word();
-        self.field_name_cache
-            .insert(name.to_owned(), converted_field_name.clone());
-        converted_field_name
+    pub fn convert_field_name(name: &str) -> String {
+        remove_reserved_identifier(name).to_snake_case_with_nums_as_word()
     }
 
     pub fn ztype_to_rust_type(&mut self, ztype: &TypeReference) -> String {
-        if ztype.is_builtin {
-            // the type is a zserio built-in type, such as int32, string, bool
-            return zserio_to_rust_type(&ztype.name)
-                .unwrap_or_else(|_| panic!("type mapping failed {:?}", &ztype.name));
+        match ztype.is_builtin {
+            true => zserio_to_rust_type(&ztype.name)
+                .unwrap_or_else(|_| panic!("type mapping failed {:?}", &ztype.name)),
+            false => {
+                assert!(!ztype.package.is_empty(), "package must be resolved");
+                format!(
+                    "{}::{}",
+                    self.zserio_package_to_rust_module(&ztype.package),
+                    Self::custom_type_to_rust_type(&ztype.name)
+                )
+            }
         }
-        // the type is a custom type, defined in some zserio file.
-        assert!(!ztype.package.is_empty(), "package must be resolved");
-        format!(
-            "{}::{}",
-            self.zserio_package_to_rust_module(&ztype.package),
-            self.custom_type_to_rust_type(&ztype.name)
-        )
     }
 
     pub fn get_full_module_path(&mut self, package: &str, rust_symbol_name: &str) -> String {
@@ -82,42 +52,26 @@ impl TypeGenerator {
         )
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_rust_module_name(&mut self, name: &str) -> String {
-        // Try to read from cache, if it already exists
-        if let Some(converted_module_name) = self.module_name_cache.get(name) {
-            return converted_module_name.clone();
-        }
-
-        let rust_module_name = remove_reserved_identifier(name).to_snake_case_with_nums_as_word();
-        self.module_name_cache
-            .insert(name.to_owned(), rust_module_name.clone());
-        rust_module_name
+    pub fn to_rust_module_name(name: &str) -> String {
+        remove_reserved_identifier(name).to_snake_case_with_nums_as_word()
     }
 
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_rust_type_name(&mut self, name: &str) -> String {
-        if let Some(converted_rust_type_name) = self.type_name_cache.get(name) {
-            return converted_rust_type_name.clone();
-        }
-        let rust_type_name = remove_reserved_identifier(name).to_pascal_case();
-        self.type_name_cache
-            .insert(name.to_owned(), rust_type_name.clone());
-        rust_type_name
+    pub fn to_rust_type_name(name: &str) -> String {
+        remove_reserved_identifier(name).to_pascal_case()
     }
 
-    pub fn custom_type_to_rust_type(&mut self, name: &str) -> String {
+    pub fn custom_type_to_rust_type(name: &str) -> String {
         format!(
             "{}::{}",
-            self.to_rust_module_name(name),
-            self.to_rust_type_name(name)
+            Self::to_rust_module_name(name),
+            Self::to_rust_type_name(name)
         )
     }
 
-    pub fn constant_type_to_rust_type(&mut self, name: &str) -> String {
+    pub fn constant_type_to_rust_type(name: &str) -> String {
         format!(
             "{}::{}",
-            self.to_rust_module_name(name),
+            Self::to_rust_module_name(name),
             to_rust_constant_name(name)
         )
     }
@@ -219,10 +173,12 @@ mod tests {
 
     #[test]
     fn test_convert_field_name() {
-        let mut tg = TypeGenerator::new("tests".into());
-        assert_eq!(tg.convert_field_name("simple"), "simple");
-        assert_eq!(tg.convert_field_name("numItems"), "num_items");
-        assert_eq!(tg.convert_field_name("boValue1"), "bo_value_1");
-        assert_eq!(tg.convert_field_name("positions2D"), "positions_2_d");
+        assert_eq!(TypeGenerator::convert_field_name("simple"), "simple");
+        assert_eq!(TypeGenerator::convert_field_name("numItems"), "num_items");
+        assert_eq!(TypeGenerator::convert_field_name("boValue1"), "bo_value_1");
+        assert_eq!(
+            TypeGenerator::convert_field_name("positions2D"),
+            "positions_2_d"
+        );
     }
 }

--- a/crates/zserio-rs-build/src/internal/generator/types.rs
+++ b/crates/zserio-rs-build/src/internal/generator/types.rs
@@ -1,8 +1,6 @@
 use crate::internal::ast::type_reference::TypeReference;
 use stringcase::Caser;
 
-const RESERVED_RUST_KEYWORDS: &[&str] = &["type", "struct", "self"];
-
 pub struct TypeGenerator {
     pub root_package_name: String,
 }
@@ -77,11 +75,14 @@ impl TypeGenerator {
     }
 }
 
-pub fn remove_reserved_identifier(name: &str) -> String {
-    if RESERVED_RUST_KEYWORDS.contains(&name.to_lowercase().as_str()) {
-        return format!("z_{}", name);
+#[inline]
+fn remove_reserved_identifier(name: &str) -> &str {
+    match name.to_ascii_lowercase().as_str() {
+        "type" => "z_type",
+        "struct" => "z_struct",
+        "self" => "z_self",
+        _ => name,
     }
-    name.into()
 }
 
 /// Translates a zserio name to a rust constant name.

--- a/crates/zserio-rs-build/src/internal/generator/zbitmask.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zbitmask.rs
@@ -20,8 +20,8 @@ pub fn generate_bitmask(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zbitmask.name);
-    let rust_type_name = type_generator.to_rust_type_name(&zbitmask.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zbitmask.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zbitmask.name);
     let fundamental_type = get_fundamental_type(&zbitmask.zserio_type, scope);
     let bitmask_rust_type = type_generator.ztype_to_rust_type(&fundamental_type.fundamental_type);
 
@@ -84,13 +84,7 @@ pub fn generate_bitmask(
     ));
 
     file_content += bitmask_scope.to_string().as_str();
-    write_to_file(
-        type_generator,
-        &file_content,
-        path,
-        package_name,
-        &rust_module_name,
-    );
+    write_to_file(&file_content, path, package_name, &rust_module_name);
     rust_module_name
 }
 

--- a/crates/zserio-rs-build/src/internal/generator/zchoice.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zchoice.rs
@@ -24,8 +24,8 @@ pub fn generate_choice(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zchoice.name);
-    let rust_type_name = type_generator.to_rust_type_name(&zchoice.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zchoice.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zchoice.name);
 
     let mut field_details = vec![];
     let mut field_idx = 0;
@@ -71,7 +71,7 @@ pub fn generate_choice(
         // painful in rust due to the lifetime checks.
         // Because I am lazy, this implementation will just copy values over.
         let gen_param_field = gen_choice.new_field(
-            type_generator.convert_field_name(&param.as_ref().borrow().name),
+            TypeGenerator::convert_field_name(&param.as_ref().borrow().name),
             param_type,
         );
         gen_param_field.vis("pub");
@@ -123,7 +123,6 @@ pub fn generate_choice(
     }
 
     write_to_file(
-        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,
@@ -141,7 +140,7 @@ pub fn generate_choice_match_construct(
     f: &dyn Fn(&ModelScope, &mut TypeGenerator, &mut Function, &FieldDetails, bool),
 ) {
     let selector_name =
-        type_generator.convert_field_name(&zchoice.selector_expression.as_ref().borrow().text);
+        TypeGenerator::convert_field_name(&zchoice.selector_expression.as_ref().borrow().text);
     let mut context_node_index = 0;
 
     code_gen_fn.line(format!("match self.{} {{", selector_name));

--- a/crates/zserio-rs-build/src/internal/generator/zconst.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zconst.rs
@@ -17,7 +17,7 @@ pub fn generate_constant(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zconst.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zconst.name);
 
     add_standard_imports(codegen_scope);
 
@@ -52,12 +52,6 @@ pub fn generate_constant(
     )
     .as_str();
 
-    write_to_file(
-        type_generator,
-        &file_content,
-        path,
-        package_name,
-        &rust_module_name,
-    );
+    write_to_file(&file_content, path, package_name, &rust_module_name);
     rust_module_name
 }

--- a/crates/zserio-rs-build/src/internal/generator/zenum.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zenum.rs
@@ -20,8 +20,8 @@ pub fn generate_enum(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zenum.name);
-    let rust_type_name = type_generator.to_rust_type_name(&zenum.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zenum.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zenum.name);
     let fundamental_type = get_fundamental_type(&zenum.enum_type, scope);
     let rust_type_type = type_generator.ztype_to_rust_type(&fundamental_type.fundamental_type);
 
@@ -116,7 +116,6 @@ pub fn generate_enum(
     ));
 
     write_to_file(
-        type_generator,
         &gen_scope.to_string(),
         path,
         package_name,
@@ -132,7 +131,7 @@ fn generate_zserio_read(
     zenum: &ZEnum,
     fundamental_type: &FundamentalZserioTypeReference,
 ) {
-    let rust_type_name = type_generator.to_rust_type_name(&zenum.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zenum.name);
     let zserio_read_fn = struct_impl.new_fn("zserio_read");
     zserio_read_fn.arg_mut_self();
     zserio_read_fn.arg("reader", "&mut BitReader");

--- a/crates/zserio-rs-build/src/internal/generator/zstruct.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zstruct.rs
@@ -27,8 +27,8 @@ pub fn generate_struct(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zstruct.name);
-    let rust_type_name = type_generator.to_rust_type_name(&zstruct.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zstruct.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zstruct.name);
 
     // For each field, convert the names and types to the rust equivalents
     let mut field_details = vec![];
@@ -61,7 +61,7 @@ pub fn generate_struct(
         // painful in rust due to the lifetime checks.
         // Because I am lazy, this implementation will just copy values over.
         let gen_param_field = gen_struct.new_field(
-            type_generator.convert_field_name(&param.as_ref().borrow().name),
+            TypeGenerator::convert_field_name(&param.as_ref().borrow().name),
             param_type,
         );
         gen_param_field.vis("pub");
@@ -114,7 +114,6 @@ pub fn generate_struct(
     }
 
     write_to_file(
-        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,

--- a/crates/zserio-rs-build/src/internal/generator/zunion.rs
+++ b/crates/zserio-rs-build/src/internal/generator/zunion.rs
@@ -26,7 +26,7 @@ pub fn generate_struct_member_for_field(
         field_type = format!("Option<{}>", field_type.as_str());
     }
     let gen_field =
-        gen_struct.new_field(type_generator.convert_field_name(&field.name), &field_type);
+        gen_struct.new_field(TypeGenerator::convert_field_name(&field.name), &field_type);
     gen_field.vis("pub");
 }
 
@@ -38,8 +38,8 @@ pub fn generate_union(
     path: &Path,
     package_name: &str,
 ) -> String {
-    let rust_module_name = type_generator.to_rust_module_name(&zunion.name);
-    let rust_type_name = type_generator.to_rust_type_name(&zunion.name);
+    let rust_module_name = TypeGenerator::to_rust_module_name(&zunion.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zunion.name);
 
     // add the imports
     add_standard_imports(codegen_scope);
@@ -100,7 +100,7 @@ pub fn generate_union(
         // painful in rust due to the lifetime checks.
         // Because I am lazy, this implementation will just copy values over.
         let gen_param_field = gen_union.new_field(
-            type_generator.convert_field_name(&param.as_ref().borrow().name),
+            TypeGenerator::convert_field_name(&param.as_ref().borrow().name),
             param_type,
         );
         gen_param_field.vis("pub");
@@ -146,7 +146,6 @@ pub fn generate_union(
     }
 
     write_to_file(
-        type_generator,
         &codegen_scope.to_string(),
         path,
         package_name,
@@ -163,7 +162,7 @@ pub fn generate_union_match_construct(
     packed: bool,
     f: &dyn Fn(&ModelScope, &mut TypeGenerator, &mut Function, &FieldDetails, bool),
 ) {
-    let rust_type_name = type_generator.to_rust_type_name(&zunion.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&zunion.name);
     let selector_type_name = format!("{}Selector", &rust_type_name);
 
     code_gen_fn.line("match &self.union_selector {");
@@ -201,7 +200,7 @@ fn generate_zserio_read(
     struct_impl: &mut codegen::Impl,
     union: &ZUnion,
 ) {
-    let rust_type_name = type_generator.to_rust_type_name(&union.name);
+    let rust_type_name = TypeGenerator::to_rust_type_name(&union.name);
     let zserio_read_fn = struct_impl.new_fn("zserio_read");
     zserio_read_fn.arg_mut_self();
     zserio_read_fn.arg("reader", "&mut BitReader");


### PR DESCRIPTION
Since a244895844a1d929013dcc04adc0e44591d866e0 case conversion is no longer a bottleneck, so we can drop the caches in `TypeGenerator`. This also makes it posisble to make most functions static. This simplifies the code, and has no performance impact.

Benchmark converting the NDS.Live schema before changes:

```
Benchmark 1: ./target/release/zserio-rs-build -o /tmp/nds/src ~/Code/nds-zserio/zs
  Time (mean ± σ):      1.974 s ±  0.083 s    [User: 1.183 s, System: 0.240 s]
  Range (min … max):    1.878 s …  2.137 s    10 runs
```

and after the changes:

```
Benchmark 1: ./target/release/zserio-rs-build -o /tmp/nds/src ~/Code/nds-zserio/zs
  Time (mean ± σ):      1.962 s ±  0.031 s    [User: 1.191 s, System: 0.242 s]
  Range (min … max):    1.920 s …  2.011 s    10 runs
```
